### PR TITLE
fix: yaml dialog will now leave App.vue loading alone, no more 403 perm error

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,20 @@
+# Ignore transient folders
+.idea
+.git
+**/logs
+**/coverage
+**/.github
+**/docker
+**/docs
+**/images
+**/fdm-monster
+**/file-storage
+
+# Ignore unuseful folders
+**/node_modules
+**/assets
+**/dist
+
+# Ignore root files
+CHANGELOG.md
+**/README.md

--- a/src/components/Generic/Dialogs/YamlImportExportDialog.vue
+++ b/src/components/Generic/Dialogs/YamlImportExportDialog.vue
@@ -2,7 +2,9 @@
   <BaseDialog
     :id="dialog.dialogId"
     max-width="700px"
-    @escape="closeDialog()">
+    @before-opened="onBeforeDialogOpened"
+    @escape="closeDialog()"
+  >
     <v-card class="pa-4">
       <v-card-title>
         <span class="text-h5">
@@ -124,11 +126,6 @@ export default defineComponent({
     }
   },
 
-  async created() {
-    await this.featureStore.loadFeatures()
-    this.exportGroups = this.featureStore.hasFeature('printerGroupsApi')
-  },
-
   data: (): Data => ({
     selectedMode: 0,
     exportFloors: true,
@@ -150,10 +147,19 @@ export default defineComponent({
 
     isImportMode() {
       return this.selectedMode === 0
-    },
+    }
+  },
+
+  async created() {
+    // Do not perform actions that might cause 401/403 handlers, or ensure they are safely handled
   },
 
   methods: {
+    async onBeforeDialogOpened() {
+      await this.featureStore.loadFeatures()
+      this.exportGroups = this.featureStore.hasFeature('printerGroupsApi')
+    },
+
     async downloadExportYamlFile() {
       if (this.exportFloorGrid) {
         this.exportPrinters = true

--- a/src/components/PrinterList/PrinterDetails.vue
+++ b/src/components/PrinterList/PrinterDetails.vue
@@ -29,10 +29,6 @@
           class="d-flex justify-end" />
       </v-col>
     </v-row>
-
-    <FileControlList
-      :file-list="printer.fileList"
-      :printer-id="printerId" />
   </v-container>
 </template>
 

--- a/src/components/PrinterList/PrintersView.vue
+++ b/src/components/PrinterList/PrintersView.vue
@@ -371,7 +371,7 @@ const openImportJsonPrintersDialog = () => {
 }
 
 const openYamlImportExportDialog = () => {
-  dialogsStore.openDialogWithContext(DialogName.YamlImportExport)
+  useDialog(DialogName.YamlImportExport).openDialog()
 }
 
 const createGroup = async () => {

--- a/src/shared/dialog.composable.ts
+++ b/src/shared/dialog.composable.ts
@@ -8,14 +8,14 @@ export function useDialog<T = any, O = any>(dialogId: DialogName) {
   async function openDialog(context?: T) {
     const beforeOpenedCallback = dialogStore.getBeforeOpenedCallback(dialogId)
     if (beforeOpenedCallback) {
-      beforeOpenedCallback(context)
+      await beforeOpenedCallback(context)
     }
 
     dialogStore.openDialogWithContext(dialogId, context)
 
     const openedCallback = dialogStore.getOpenedCallback(dialogId)
     if (openedCallback) {
-      openedCallback(context)
+      await openedCallback(context)
     }
   }
 

--- a/src/store/dialog.store.ts
+++ b/src/store/dialog.store.ts
@@ -4,8 +4,8 @@ import { DialogName } from '@/components/Generic/Dialogs/dialog.constants'
 interface DialogReference<T = any> {
   id: DialogName;
   opened: boolean;
-  beforeOpenedCallback?: (input?: T) => void;
-  openedCallback?: (input?: T) => void;
+  beforeOpenedCallback?: (input?: T) => void | Promise<void>;
+  openedCallback?: (input?: T) => void | Promise<void>;
   context?: any;
   output?: any;
 }
@@ -94,7 +94,9 @@ export const useDialogsStore = defineStore('Dialog', {
       console.debug(`[Pinia Dialog ${id}] Registered`)
       const existingDialog = this.dialogsById[id]
       if (existingDialog) {
-        console.debug(`[Pinia Dialog ${id}]  Already registered dialog, not registering again`)
+        console.debug(
+          `[Pinia Dialog ${id}]  Already registered dialog, not registering again`
+        )
         return existingDialog
       }
 

--- a/src/store/features.store.ts
+++ b/src/store/features.store.ts
@@ -1,5 +1,9 @@
 import { defineStore } from 'pinia'
-import { TFeatureFlags, FeaturesModel, IFeatureFlag } from '@/models/server/features.model'
+import {
+  TFeatureFlags,
+  FeaturesModel,
+  IFeatureFlag,
+} from '@/models/server/features.model'
 import { AppService } from '@/backend/app.service'
 
 interface State {
@@ -20,13 +24,16 @@ export const useFeatureStore = defineStore('Feature', {
           if (!state.features) {
             console.debug('Feature store not loaded')
             return false
-          } else {
-            console.debug('Feature store loaded')
           }
 
-          const featureDefined = state.features[feature] as IFeatureFlag | undefined
+          const featureDefined = state.features[feature] as
+          | IFeatureFlag
+          | undefined
           if (!featureDefined) {
-            console.debug(`Feature ${feature} not defined. Options:`, Object.keys(state.features))
+            console.debug(
+              `Feature ${feature} not defined. Options:`,
+              Object.keys(state.features)
+            )
             return false
           }
 
@@ -35,6 +42,7 @@ export const useFeatureStore = defineStore('Feature', {
   },
   actions: {
     async loadFeatures() {
+      debugger
       try {
         const features = await AppService.getFeatures()
         this.setFeatures(features)


### PR DESCRIPTION
fix: yaml dialog will now leave App.vue loading alone, no more 403 perm error

Refer to https://github.com/fdm-monster/fdm-monster-client/pull/1176