### PR TITLE
release: 0.0.5 - api key length 43 validation

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,3 +1,9 @@
+# Client 0.0.5
+
+Fixes:
+
+- Printer dialog: api key of 43 length should be allowed since OctoPrint 1.10.3
+ 
 # Client 0.0.4
 
 ## Fixes:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@fdm-monster/client-next",
+  "version": "0.0.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fdm-monster/fdm-monster-client-next.git"
@@ -9,7 +10,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.4",
   "description": "FDM Monster Client Next is the Vue3 frontend for FDM Monster.",
   "scripts": {
     "dev": "vite",

--- a/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
+++ b/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
@@ -57,7 +57,7 @@
               v-model="formData.apiKey"
               :counter="apiKeyRules.length"
               class="ma-1"
-              hint="User or Application Key only (Global API key fails)"
+              hint="User or Application Key with 32 or 43 characters (Global API key will fail)"
               label="API Key*"
               persistent-hint
               required

--- a/src/shared/app.constants.ts
+++ b/src/shared/app.constants.ts
@@ -13,7 +13,7 @@ export interface AppConstants {
 
 export const generateAppConstants = (): Readonly<AppConstants> =>
   Object.freeze({
-    apiKeyLength: 32,
+    apiKeyLength: 43,
     maxPort: 65535,
     maxPrinterNameLength: 25,
     maxPrinterGroupNameLength: 30, // Doesn't exist on backend


### PR DESCRIPTION
fix: printer dialog: api key of 43 length should be allowed since OctoPrint 1.10.3

Associated with https://github.com/fdm-monster/fdm-monster/issues/3752
Ports over this fix: https://github.com/fdm-monster/fdm-monster-client/pull/1687