### PR TITLE
fix: when deleting a printer, an error is often presented that the PrinterStore contains no printer with such id

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,9 @@
 # Develop 
 
+## Fixes
+
+- PrinterStore: when deleting a printer, an error is often presented that the PrinterStore contains no printer with such id
+
 ## Features:
 
 - User settings: create user dialog for an admin to conveniently share a new verified account with roles.

--- a/src/components/Generic/Actions/PrinterDeleteAction.vue
+++ b/src/components/Generic/Actions/PrinterDeleteAction.vue
@@ -14,16 +14,21 @@
 import { defineProps } from 'vue'
 import { PrinterDto } from '@/models/printers/printer.model'
 import { usePrinterStore } from '@/store/printer.store'
+import { usePrinterStateStore } from '@/store/printer-state.store'
 
 const props = defineProps<{
   printer: PrinterDto
 }>()
 
 const printersStore = usePrinterStore()
+const printerStateStore = usePrinterStateStore()
 
 async function deletePrinter() {
   if (!confirm('Are you sure to delete this printer?')) return
 
   await printersStore.deletePrinter(props.printer.id)
+
+  // This is a best-effort, the socket-io updates will decide eventually
+  printerStateStore.deletePrinterEvents(props.printer.id)
 }
 </script>


### PR DESCRIPTION
Related to https://github.com/fdm-monster/fdm-monster-client/pull/1696

Description
This is an inconsistency coming from the backend which has no "deleted" or "updated" mechanism. Also there is no state normalization, so the frontend cannot correctly see which entities should be updated and which should be silenced/deleted.

Fixes https://github.com/fdm-monster/fdm-monster/issues/3778