### PR TITLE
feat: auto-append https if this is missing in URL before submitting

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -3,6 +3,7 @@
 ## Fixes
 
 - PrinterStore: when deleting a printer, an error is often presented that the PrinterStore contains no printer with such id
+- AddOrUpdatePrinterDialog: auto-append https if this is missing in URL before submitting
 
 ## Features:
 

--- a/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
+++ b/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
@@ -60,7 +60,6 @@
           <v-col :cols="showChecksPanel ? 8 : 12">
             <v-row v-if="formData">
               <v-col>
-                <!--                  :rules="printerNameRules"-->
                 <v-text-field
                   v-model="formData.name"
                   :counter="printerNameRules.max"
@@ -97,7 +96,6 @@
               persistent-hint
               required
             />
-            <!--            </validation-provider>-->
           </v-col>
 
           <PrinterChecksPanel
@@ -323,11 +321,19 @@ async function updatePrinter(updatedPrinter: CreatePrinter) {
 }
 
 async function submit() {
-  // if (!(await isValid())) return
   if (!formData) return
 
   printerValidationError.value = null
   validatingPrinter.value = true
+
+  if (
+    formData.value.printerURL?.length &&
+    !formData.value.printerURL?.startsWith('http://') &&
+    !formData.value.printerURL?.startsWith('https://')
+  ) {
+    formData.value.printerURL += 'https://'
+  }
+
   const createdPrinter = formData.value as CreatePrinter
 
   try {


### PR DESCRIPTION
Related to https://github.com/fdm-monster/fdm-monster-client/pull/1697

Fixes https://github.com/fdm-monster/fdm-monster/issues/3774

Make users aware that URLs should be prefixed explicitly.