### PR TITLE
feat: remove whitelist settings from UI

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,9 @@
 # Develop 
 
+Features
+
+- Remove whitelist settings from UI
+
 # Client 0.0.8
 
 ## Fixes

--- a/src/backend/server.api.ts
+++ b/src/backend/server.api.ts
@@ -47,7 +47,6 @@ export class ServerApi {
   static serverSettingsRoute = `${ServerApi.settingsRoute}/server`
   static fileCleanSettingsRoute = `${ServerApi.settingsRoute}/file-clean`
   static updateFrontendSettingsRoute = `${ServerApi.settingsRoute}/frontend`
-  static updateServerWhitelistSettingRoute = `${ServerApi.settingsRoute}/whitelist`
   static updateTimeoutSettingRoute = `${ServerApi.settingsRoute}/timeout`
   static serverSentryDiagnosticsSettingRoute = `${ServerApi.settingsRoute}/sentry-diagnostics`
   static updateExperimentalMoonrakerSupportRoute = `${ServerApi.settingsRoute}/experimental-moonraker-support`

--- a/src/backend/settings.service.ts
+++ b/src/backend/settings.service.ts
@@ -7,7 +7,6 @@ import {
   SettingsSensitiveDto
 } from '@/models/settings/settings.model'
 import { FileCleanSettings } from '@/models/settings/printer-file-clean-settings.model'
-import { WhitelistSettings } from '@/models/settings/server-settings.dto'
 
 export class SettingsService extends BaseService {
   static async getSettings() {
@@ -58,12 +57,6 @@ export class SettingsService extends BaseService {
   static async setSentryDiagnosticsSettings(enabled: boolean) {
     const path = `${ServerApi.serverSentryDiagnosticsSettingRoute}`
     return await this.patch(path, { enabled })
-  }
-
-  static async setWhitelistSettings(subSettings: WhitelistSettings) {
-    const path = `${ServerApi.updateServerWhitelistSettingRoute}`
-
-    await this.put(path, subSettings as WhitelistSettings)
   }
 
   static async updateTimeoutSettings(subSettings: TimeoutSettings) {

--- a/src/components/Settings/ServerProtectionSettings.vue
+++ b/src/components/Settings/ServerProtectionSettings.vue
@@ -7,78 +7,6 @@
       <v-toolbar-title> Server Protection Settings </v-toolbar-title>
     </v-toolbar>
     <v-list lines="three">
-      <v-list-item v-if="!whitelistSettingsHidden">
-        <v-list-item-title> IP Whitelist </v-list-item-title>
-        <v-list-item-subtitle>
-          <v-alert color="warning">
-            <v-icon>info</v-icon> &nbsp; Be cautious, setting the wrong
-            whitelist could make you lose access to the server!
-          </v-alert>
-          Only allow access from specific IP Adresses or subnets. Note:
-          127.0.0.1 will always be allowed access. Examples:
-          <br />
-          <v-chip size="small"> 192.168 </v-chip>
-          <v-chip size="small"> 192.168.1 </v-chip>
-          <v-chip size="small"> 192.168.1.1 </v-chip>
-          <br />
-          <v-row>
-            <v-col
-              cols="12"
-              md="2"
-            >
-              <v-checkbox
-                v-model="whitelistEnabled"
-                label="Enable IP Whitelist"
-              />
-            </v-col>
-          </v-row>
-          <v-row class="mt-0">
-            <v-col
-              cols="12"
-              md="2"
-            >
-              <v-text-field
-                v-model="ipAddress"
-                :disabled="!whitelistEnabled"
-                :rules="[ipAddressRule, (val) => !!val]"
-                append-icon="add"
-                label="IP Address"
-                @click:append="appendIpAddress(ipAddress)"
-              />
-            </v-col>
-            <v-col>
-              <v-chip-group>
-                <v-chip
-                  v-for="ip in whitelistedIpAddresses"
-                  :key="ip"
-                  :disabled="!whitelistEnabled"
-                  closable
-                  @click:close="removeIpWhitelist(ip)"
-                >
-                  {{ ip }}
-                </v-chip>
-              </v-chip-group>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-btn
-                color="default"
-                @click="resetWhitelistSettingsToDefault()"
-              >
-                reset to default
-              </v-btn>
-              <v-btn
-                color="primary"
-                @click="setWhitelistSettings()"
-              >
-                save whitelist settings
-              </v-btn>
-            </v-col>
-          </v-row>
-        </v-list-item-subtitle>
-      </v-list-item>
-
       <v-list-item>
         <v-list-item-title> Login Required </v-list-item-title>
 
@@ -221,8 +149,6 @@
 
 <script lang="ts" setup>
 import { onMounted, ref } from 'vue'
-import { whitelistSettingsHidden } from '@/shared/experimental.constants'
-import { isValidIPOrMask } from '@/utils/validation.utils'
 import { SettingsService } from '@/backend'
 import { useSnackbar } from '@/shared/snackbar.composable'
 import { useAuthStore } from '@/store/auth.store'
@@ -234,8 +160,6 @@ const snackbar = useSnackbar()
 const authStore = useAuthStore()
 
 const ipAddress = ref<string>('')
-const whitelistEnabled = ref<boolean>(false)
-const whitelistedIpAddresses = ref<string[]>([])
 
 const loginRequired = ref<boolean>(false)
 const registrationEnabled = ref<boolean>(false)
@@ -245,17 +169,12 @@ const refreshTokenAttemptsEnabled = ref<boolean>(false)
 const refreshTokenAttempts = ref<number>(-1)
 const refreshTokenExpiry = ref<number>(14)
 
-const ipAddressRule = (val: string) =>
-  isValidIPOrMask(val) ? true : 'Not a valid IP Address'
-
 async function loadSettings() {
   const settings = await SettingsService.getSettings()
   loginRequired.value = settings.server.loginRequired
   registrationEnabled.value = settings.server.registration
 
   ipAddress.value = settings.connection?.clientIp ?? '127.0.0.1'
-  whitelistEnabled.value = settings.server.whitelistEnabled
-  whitelistedIpAddresses.value = settings.server.whitelistedIpAddresses
 
   const sensitiveSettings = await SettingsService.getSettingsSensitive()
   jwtExpiresIn.value = sensitiveSettings.credentials.jwtExpiresIn / 60
@@ -275,36 +194,6 @@ function onRefreshTokenEnabledChange() {
   if (!refreshTokenAttemptsEnabled.value) {
     refreshTokenAttempts.value = -1
   }
-}
-
-function removeIpWhitelist(removedIp: string) {
-  whitelistedIpAddresses.value = whitelistedIpAddresses.value.filter(
-    (ip) => ip.toLowerCase() !== removedIp.toLowerCase()
-  )
-}
-
-function appendIpAddress(ip: string) {
-  if (!isValidIPOrMask(ip)) return
-  whitelistedIpAddresses.value.push(ip.toLowerCase())
-}
-
-async function resetWhitelistSettingsToDefault() {
-  whitelistedIpAddresses.value = ['127.0.0.1', '::12']
-  whitelistEnabled.value = false
-  await setWhitelistSettings(false)
-  snackbar.info('Whitelist settings reset to default')
-}
-
-async function setWhitelistSettings(showSuccess = true) {
-  await SettingsService.setWhitelistSettings({
-    whitelistedIpAddresses: whitelistedIpAddresses.value,
-    whitelistEnabled: whitelistEnabled.value
-  })
-  if (showSuccess) {
-    snackbar.info('Whitelist settings updated')
-  }
-
-  await loadSettings()
 }
 
 async function setLoginRequired() {

--- a/src/models/settings/server-settings.dto.ts
+++ b/src/models/settings/server-settings.dto.ts
@@ -1,8 +1,3 @@
-export interface WhitelistSettings {
-  whitelistedIpAddresses: string[]
-  whitelistEnabled: boolean
-}
-
 export interface DebugSettings {
   debugSocketIoEvents: boolean
   debugSocketReconnect: boolean
@@ -12,7 +7,7 @@ export interface DebugSettings {
   debugSocketIoBandwidth: boolean
 }
 
-export interface ServerSettingsDto extends WhitelistSettings {
+export interface ServerSettingsDto {
   sentryDiagnosticsEnabled: boolean
   loginRequired: boolean
   registration: boolean

--- a/src/models/settings/settings.model.ts
+++ b/src/models/settings/settings.model.ts
@@ -9,7 +9,6 @@ export interface FrontendSettings {
 
 export interface ConnectionInfo {
   clientIp: string
-  ip: string
   version: string
 }
 

--- a/src/models/settings/settings.model.ts
+++ b/src/models/settings/settings.model.ts
@@ -47,8 +47,6 @@ export interface ServerSettingsSensitiveDto {
     debugSocketMessages: boolean
     debugSocketIoBandwidth: boolean
   }
-  whitelistEnabled: boolean
-  whitelistedIpAddresses: string[]
 }
 
 export interface SettingsSensitiveDto {

--- a/src/shared/experimental.constants.ts
+++ b/src/shared/experimental.constants.ts
@@ -1,1 +1,0 @@
-export const whitelistSettingsHidden = true


### PR DESCRIPTION
This removes the whitelist setting from server protection page. This was a hidden feature and experimental.

Associated with https://github.com/fdm-monster/fdm-monster/pull/3784
Fixes part of https://github.com/fdm-monster/fdm-monster/issues/3732
Backport of https://github.com/fdm-monster/fdm-monster-client/pull/1700