### PR TITLE
fix: deleting or downloading a file path is now encoded in url path

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,9 @@
 # Develop 
 
+## Fixes
+
+- File delete/download: Deleting or downloading a file path is now encoded in url path
+ 
 # Client 0.0.11
 
 ## Fixes

--- a/src/backend/printer-file.service.ts
+++ b/src/backend/printer-file.service.ts
@@ -67,12 +67,16 @@ export class PrinterFileService extends BaseService {
   }
 
   static async deleteFileOrFolder(printerId: IdType, path: string) {
-    const urlPath = `${ServerApi.printerFilesRoute}/${printerId}?path=${path}`
+    const urlPath = `${
+      ServerApi.printerFilesRoute
+    }/${printerId}?path=${encodeURIComponent(path)}`
     return this.delete(urlPath)
   }
 
   static async downloadFile(printerId: IdType, path: string) {
-    const urlPath = `${ServerApi.printerFilesRoute}/${printerId}/download/${path}`
+    const urlPath = `${
+      ServerApi.printerFilesRoute
+    }/${printerId}/download/${encodeURIComponent(path)}`
     const arrayBuffer = await this.getDownload(urlPath)
     downloadFileByBlob(arrayBuffer.data, path)
   }


### PR DESCRIPTION
Fixes frontend part of https://github.com/fdm-monster/fdm-monster/issues/3800
Port of https://github.com/fdm-monster/fdm-monster-client/pull/1744