### PR TITLE
fix: clicking on an empty tile should not enable grid mode, settings: use constant map

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -3,6 +3,8 @@
 ## Fixes
 
 - Vuetify Tooltip: improve styling of tooltip for better legibility
+- Settings: use constants settings map
+- Printer tile: clicking on an empty tile should not enable grid mode
 
 # Client 0.0.15
 

--- a/src/components/PrinterGrid/PrinterGridTile.vue
+++ b/src/components/PrinterGrid/PrinterGridTile.vue
@@ -500,7 +500,6 @@ const clickConnectUsb = async () => {
 
 const selectOrClearPrinterPosition = async () => {
   if (!props.printer || !printerId.value) {
-    gridStore.gridEditMode = true
     return
   }
 
@@ -552,6 +551,7 @@ const selectOrClearPrinterPosition = async () => {
 
 .tile-no-printer:hover {
   background-color: #2a2a2a;
+  cursor: not-allowed;
 }
 
 .plus-hover-icon {

--- a/src/components/Settings/SettingsView.vue
+++ b/src/components/Settings/SettingsView.vue
@@ -4,7 +4,7 @@
       <v-navigation-drawer :permanent="true">
         <v-list-item>
           <v-list-item-title class="text-h6"> Settings </v-list-item-title>
-          <v-list-item-subtitle> Adjust your Fdm Monster </v-list-item-subtitle>
+          <v-list-item-subtitle> Adjust your FDM Monster </v-list-item-subtitle>
         </v-list-item>
 
         <v-divider />
@@ -34,67 +34,7 @@
 </template>
 
 <script lang="ts" setup>
-const items = ref([
-  {
-    title: 'Grid',
-    icon: 'grid_on',
-    path: '/settings/grid',
-    divider: false
-  },
-  {
-    title: 'Floors',
-    icon: 'house_siding',
-    path: '/settings/floors',
-    divider: true
-  },
-  {
-    title: 'OctoPrint',
-    icon: 'image',
-    path: '/settings/octoprint',
-    divider: false
-  },
+import { settingsPage } from '@/components/Settings/Shared/setting.constants'
 
-  {
-    title: 'Emergency Commands',
-    icon: 'warning',
-    path: '/settings/emergency-commands',
-    divider: true
-  },
-  {
-    title: 'Users',
-    icon: 'group',
-    path: '/settings/user-management',
-    divider: false
-  },
-  {
-    title: 'Account',
-    icon: 'account_circle',
-    path: '/settings/account',
-    divider: false
-  },
-  {
-    title: 'Server Protection',
-    icon: 'security',
-    path: '/settings/server-protection',
-    divider: true
-  },
-  {
-    title: 'Software Upgrade',
-    icon: 'upgrade',
-    path: '/settings/software-upgrade',
-    divider: false
-  },
-  {
-    title: 'Diagnostics',
-    icon: 'bug_report',
-    path: '/settings/diagnostics',
-    divider: false
-  },
-  {
-    title: 'Experimental',
-    icon: 'settings_applications',
-    path: '/settings/experimental',
-    divider: false
-  }
-])
+const items = ref(settingsPage)
 </script>

--- a/src/components/Settings/Shared/SettingSection.vue
+++ b/src/components/Settings/Shared/SettingSection.vue
@@ -1,0 +1,44 @@
+<template>
+  <v-list
+    subheader
+    three-line
+  >
+    <v-list-subheader>
+      <span class="pr-3">
+        {{ props.title }}
+      </span>
+
+      <v-tooltip
+        bottom
+        v-if="props.tooltip?.length"
+      >
+        <template v-slot:activator="{ props }">
+          <v-icon
+            class="help-icon"
+            v-bind="props"
+            >help_outline</v-icon
+          >
+        </template>
+        <span class="tooltip-content">
+          {{ tooltip }}
+        </span>
+      </v-tooltip>
+    </v-list-subheader>
+    <v-list-item>
+      <v-list-item-media>
+        <v-row>
+          <v-col cols="3">
+            <slot></slot>
+          </v-col>
+        </v-row>
+      </v-list-item-media>
+    </v-list-item>
+  </v-list>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  title: string
+  tooltip?: string
+}>()
+</script>

--- a/src/components/Settings/Shared/setting.constants.ts
+++ b/src/components/Settings/Shared/setting.constants.ts
@@ -1,0 +1,75 @@
+export const settingPage = {
+  grid: "grid",
+  floors: "floors",
+  octoprint: "octoprint",
+  emergencyCommands: "emergencyCommands",
+  users: "users",
+  account: "account",
+  serverProtection: "serverProtection",
+  softwareUpgrade: "softwareUpgrade",
+  diagnostics: "diagnostics",
+  experimental: "experimental",
+} as const;
+
+export const settingsPage = {
+  [settingPage.grid]: {
+    title: "Grid",
+    icon: "grid_on",
+    path: "/settings/grid",
+    divider: false,
+  },
+  [settingPage.floors]: {
+    title: "Floors",
+    icon: "house_siding",
+    path: "/settings/floors",
+    divider: true,
+  },
+  [settingPage.octoprint]: {
+    title: "OctoPrint",
+    icon: "image",
+    path: "/settings/octoprint",
+    divider: false,
+  },
+  [settingPage.emergencyCommands]: {
+    title: "Emergency Commands",
+    icon: "warning",
+    path: "/settings/emergency-commands",
+    divider: true,
+  },
+  [settingPage.users]: {
+    title: "Users",
+    icon: "group",
+    path: "/settings/user-management",
+    divider: false,
+  },
+  [settingPage.account]: {
+    title: "Account",
+    icon: "account_circle",
+    path: "/settings/account",
+    divider: false,
+  },
+  [settingPage.serverProtection]: {
+    title: "Server Protection",
+    icon: "security",
+    path: "/settings/server-protection",
+    divider: true,
+  },
+  [settingPage.softwareUpgrade]: {
+    title: "Software Upgrade",
+    icon: "upgrade",
+    path: "/settings/software-upgrade",
+    divider: false,
+  },
+  [settingPage.diagnostics]: {
+    title: "Diagnostics",
+    icon: "bug_report",
+    path: "/settings/diagnostics",
+    divider: false,
+  },
+  [settingPage.experimental]: {
+    title: "Experimental",
+    icon: "settings_applications",
+    path: "/settings/experimental",
+    divider: false,
+  },
+} as const;


### PR DESCRIPTION
Port of https://github.com/fdm-monster/fdm-monster-client/pull/1806 and part of https://github.com/fdm-monster/fdm-monster-client/pull/1791

![image](https://github.com/user-attachments/assets/d5d95a11-0746-4210-a739-dc3bcccd2a86)
Clicking the empty tile would enable grid edit mode. Unexpected behaviour.

Also settings now use a common definition (constant map) 