### PR TITLE
fix: delete all files should have a confirmation dialog

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,9 +1,13 @@
 # Develop
 
-Chores
+## Chores
 
 - Adjust server version api response (no more isPm2 or isNodemon flags)
 
+## Fixes
+
+- Delete files on printer details (sidenav) should be protected by a confirmation dialog.
+ 
 # Client 0.0.16
 
 ## Fixes

--- a/src/components/Generic/FileExplorerSideNav.vue
+++ b/src/components/Generic/FileExplorerSideNav.vue
@@ -323,7 +323,7 @@
             class="extra-dense-list-item"
             link
             v-bind="props"
-            @click.prevent.stop="clickClearFiles()"
+            @click.prevent.stop="clickDeleteAllFiles()"
           >
             <v-avatar :size="iconSize">
               <v-icon> delete </v-icon>
@@ -729,10 +729,14 @@ async function clickResumePrint() {
   await PrinterJobService.resumePrintJob(printerId.value)
 }
 
-async function clickClearFiles() {
+async function clickDeleteAllFiles() {
   if (!printerId.value) return
+  if (!confirm('Are you sure to delete all files for this printer?')) {
+    return
+  }
+
   loading.value = true
-  await printersStore.clearPrinterFiles(printerId.value)
+  await printersStore.deletePrinterFiles(printerId.value)
   loading.value = false
   shownFileCache.value = printersStore.printerFiles(printerId.value)
 }

--- a/src/store/printer.store.ts
+++ b/src/store/printer.store.ts
@@ -170,7 +170,7 @@ export const usePrinterStore = defineStore('Printers', {
         )
       }
     },
-    async clearPrinterFiles(printerId: IdType) {
+    async deletePrinterFiles(printerId: IdType) {
       if (!printerId) {
         throw new Error('No printerId was provided')
       }


### PR DESCRIPTION
Port of https://github.com/fdm-monster/fdm-monster-client/pull/1807
Fixes https://github.com/fdm-monster/fdm-monster/issues/3947

![image](https://github.com/user-attachments/assets/e15571bd-01bf-4ae3-a8e6-f638bfd3c9b0)
The delete files option is currently unprotected against misclicks.