### PR TITLE
Updates API endpoint for printer quick stop

### DIFF
--- a/src/backend/printers.service.ts
+++ b/src/backend/printers.service.ts
@@ -52,6 +52,12 @@ export class PrintersService extends BaseService {
     return (await this.post(path)) as any;
   }
 
+  static async postQuickStopM112Command(printerId: number) {
+    const path = ServerApi.sendQuickStopM112Route(printerId)
+
+    return await this.post(path)
+  }
+
   static async sendPrinterConnectCommand(printerId: number) {
     const path = ServerApi.printerSerialConnectRoute(printerId);
 

--- a/src/backend/server.api.ts
+++ b/src/backend/server.api.ts
@@ -17,7 +17,6 @@ export class ServerApi {
   static readonly printerFilesPurgeRoute = `${ServerApi.printerFilesRoute}/purge`
   static readonly printerTagsRoute = `${ServerApi.base}/printer-group`
   static readonly createGroupRoute = `${ServerApi.base}/printer-group`
-  static readonly customGCodeRoute = `${ServerApi.base}/custom-gcode`
   static readonly userRoute = `${ServerApi.base}/user`
   static readonly rolesRoute = `${ServerApi.base}/user/roles`
   static readonly userProfileRoute = `${ServerApi.userRoute}/profile`
@@ -63,7 +62,7 @@ export class ServerApi {
   static readonly addOrRemovePrinterFromFloorRoute = (id: number) =>
     `${ServerApi.getFloorRoute(id)}/printer`
   static readonly sendQuickStopM112Route = (id: number) =>
-    `${ServerApi.customGCodeRoute}/send-emergency-m112/${id}`
+    `${ServerApi.printerRoute}/${id}/send-emergency-m112`
   static readonly updatePrinterFloorNameRoute = (id: number) =>
     `${ServerApi.getFloorRoute(id)}/name`
   static readonly updatePrinterFloorNumberRoute = (id: number) =>

--- a/src/components/Generic/Actions/PrinterQuickStopAction.vue
+++ b/src/components/Generic/Actions/PrinterQuickStopAction.vue
@@ -25,8 +25,8 @@
 
 <script lang="ts" setup>
 import { PrinterDto } from '@/models/printers/printer.model'
-import { CustomGcodeService } from '@/backend/custom-gcode.service'
 import { hasEmergencyStop } from '@/shared/printer-capabilities.constants'
+import { PrintersService } from "@/backend";
 
 const props = defineProps<{
   printer: PrinterDto
@@ -35,6 +35,6 @@ const props = defineProps<{
 async function clickQuickStop() {
   if (!confirm('Are you sure to quick stop this printer?')) return
 
-  await CustomGcodeService.postQuickStopM112Command(props.printer.id)
+  await PrintersService.postQuickStopM112Command(props.printer.id)
 }
 </script>

--- a/src/styles/vuetify-variables.d.css
+++ b/src/styles/vuetify-variables.d.css
@@ -16,4 +16,5 @@
     --v-theme-on-warning: ;
     --v-theme-on-background: ;
     --v-theme-on-surface: ;
+    --v-theme-surface-variant: ;
 }

--- a/src/utils/sentry.util.ts
+++ b/src/utils/sentry.util.ts
@@ -4,5 +4,7 @@ export function setSentryEnabled(enabled: boolean) {
   const client = Sentry.getClient()
   // @ts-ignore
   client.getOptions().enabled = enabled
-  console.warn('Sentry enabled:', enabled)
+  if (enabled) {
+    console.warn('Sentry enabled:', enabled)
+  }
 }


### PR DESCRIPTION
Updates the API endpoint used for sending the quick stop command to printers.

This change moves the quick stop functionality to a more appropriate printer-specific route and removes the dedicated custom G-code route. It also updates the PrintersService and the PrinterQuickStopAction component to reflect this change.