### PR TITLE
Removes filament length from job details

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,9 @@
 # Develop
 
+## Client 2.2.5
+
+- Remove filament length on Job page / dialog
+
 ## Client 2.2.4
 
 Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fdm-monster/client-next",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fdm-monster/fdm-monster-client-next.git"

--- a/src/components/Files/FilesView.vue
+++ b/src/components/Files/FilesView.vue
@@ -195,11 +195,11 @@
           <template #item.filament="{ item }">
             <div v-if="item.metadata?.filamentUsedGrams" class="text-body-2">
               <v-chip
-                color="purple"
+                color="green"
                 size="small"
                 variant="tonal"
               >
-                <v-icon start size="small">science</v-icon>
+                <v-icon start size="small">fitness_center</v-icon>
                 {{ item.metadata.filamentUsedGrams.toFixed(1) }}g
               </v-chip>
             </div>

--- a/src/components/PrintJobs/PrintJobDetailsDialog.vue
+++ b/src/components/PrintJobs/PrintJobDetailsDialog.vue
@@ -151,25 +151,19 @@
                 </v-card-title>
                 <v-card-text>
                   <v-row dense>
-                    <v-col cols="6" md="3">
+                    <v-col cols="6" md="4">
                       <div class="text-caption text-medium-emphasis">Used (Grams)</div>
                       <div class="text-h6 text-green">
                         {{ Math.round(job?.metadata?.filamentUsedGrams || 0) }}g
                       </div>
                     </v-col>
-                    <v-col cols="6" md="3">
-                      <div class="text-caption text-medium-emphasis">Used (Length)</div>
-                      <div class="text-h6 text-green">
-                        {{ Math.round((job?.metadata?.filamentUsedMm || 0) / 1000) }}m
-                      </div>
-                    </v-col>
-                    <v-col cols="6" md="3">
+                    <v-col cols="6" md="4">
                       <div class="text-caption text-medium-emphasis">Filament Type</div>
                       <div class="text-body-2">
                         {{ job?.metadata?.filamentType || 'Unknown' }}
                       </div>
                     </v-col>
-                    <v-col cols="6" md="3">
+                    <v-col cols="6" md="4">
                       <div class="text-caption text-medium-emphasis">Nozzle Ø</div>
                       <div class="text-body-2">
                         {{ job?.metadata?.nozzleDiameterMm || 'N/A' }}mm

--- a/src/components/PrintJobs/PrintJobs.vue
+++ b/src/components/PrintJobs/PrintJobs.vue
@@ -374,20 +374,16 @@
 
           <!-- Filament Column -->
           <template #item.filament="{ item }">
-            <div v-if="activeTab === 'jobs' && (item.metadata?.filamentUsedGrams || item.metadata?.filamentUsedMm)"
+            <div v-if="activeTab === 'jobs' && item.metadata?.filamentUsedGrams"
                  class="filament-info">
               <v-chip
                 color="green"
                 size="small"
                 variant="tonal"
-                v-if="item.metadata?.filamentUsedGrams"
               >
                 <v-icon start size="small">fitness_center</v-icon>
                 {{ Math.round(item.metadata.filamentUsedGrams) }}g
               </v-chip>
-              <div v-if="item.metadata?.filamentUsedMm" class="text-caption text-medium-emphasis mt-1">
-                {{ Math.round(item.metadata.filamentUsedMm / 1000) }}m
-              </div>
             </div>
             <div v-else-if="activeTab === 'queue' && item.filamentGrams" class="text-body-2">
               <v-chip


### PR DESCRIPTION
Removes the display of filament length from the job details dialog and job page to address issue 1435.

Updates:
- Removes filament length display in PrintJobDetailsDialog.vue
- Removes filament length display in PrintJobs.vue
- Updates RELEASE_NOTES.MD
- Updates package.json version

<img width="126" height="59" alt="image" src="https://github.com/user-attachments/assets/888888fd-28f5-4247-9c7c-de9013f5f62d" />
