### PR TITLE
Shows filename when deleting files

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,11 @@
 # Develop
 
+## Client 2.3.3
+
+Fixes
+
+- ID shown instead of original filename in alert when deleting file on Files page
+
 ## Client 2.3.2
 
 Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fdm-monster/client-next",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fdm-monster/fdm-monster-client-next.git"

--- a/src/components/Files/FilesView.vue
+++ b/src/components/Files/FilesView.vue
@@ -449,7 +449,7 @@ const viewFile = (file: FileMetadata) => {
 }
 
 const deleteFile = async (file: FileMetadata) => {
-  if (!confirm(`Delete file "${file.fileName}"? This cannot be undone.`)) {
+  if (!confirm(`Delete file "${file.metadata?._originalFileName || file.fileName}"? This cannot be undone.`)) {
     return
   }
 


### PR DESCRIPTION
Fixes an issue where the file ID was displayed instead of the original filename in the confirmation alert when deleting a file.

This change improves the user experience by ensuring the correct filename is shown, preventing confusion during file deletion.

Relates to #1509