### PR TITLE
feat(printer-side-nav): persist drawer state in URL query

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -50,11 +50,14 @@ import { useUploadsStore } from './store/uploads.store'
 import { uploadProgressTest } from './utils/test.util'
 import { useAuthStore } from './store/auth.store'
 import { useOverlayStore } from './store/overlay.store'
+import { useFileExplorerUrlSync } from './shared/file-explorer-url-sync.composable'
 import AppLoader from './AppLoader.vue'
 
 const uploadsStore = useUploadsStore()
 const authStore = useAuthStore()
 const appLoaderStore = useOverlayStore()
+
+useFileExplorerUrlSync()
 
 const queuedUploads = uploadsStore.queuedUploads
 

--- a/src/components/Generic/FileExplorerSideNav.vue
+++ b/src/components/Generic/FileExplorerSideNav.vue
@@ -588,8 +588,9 @@ watch(printerId, async (newPrinterId, oldPrinterId) => {
 // bookmark, share-link, and browser back/forward all do the right thing.
 
 function parseRouteSidenav() {
-  const idRaw = route.query.sidenav
-  const id = idRaw != null ? Number(idRaw) : NaN
+  // Number(undefined) -> NaN and Number(null) -> 0, both caught by `id > 0`
+  // and Number.isFinite below — no need for an explicit nullish branch.
+  const id = Number(route.query.sidenav)
   const path = typeof route.query.path === 'string' ? route.query.path : ''
   return {
     id: Number.isFinite(id) && id > 0 ? id : undefined,

--- a/src/components/Generic/FileExplorerSideNav.vue
+++ b/src/components/Generic/FileExplorerSideNav.vue
@@ -417,8 +417,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { computed, ref, watch } from 'vue'
 import { generateInitials } from '@/shared/noun-adjectives.data'
 import { PrinterRemoteFileService, PrintersService } from '@/backend'
 import { PrinterMaintenanceLogService } from '@/backend/printer-maintenance-log.service'
@@ -446,8 +445,6 @@ interface TreeNode {
 const printersStore = usePrinterStore()
 const printerStateStore = usePrinterStateStore()
 const fileExplorer = useFileExplorer()
-const route = useRoute()
-const router = useRouter()
 
 const fileSearch = ref<string | undefined>(undefined)
 const fileList = ref<FileDto[] | undefined>(undefined)
@@ -582,83 +579,6 @@ watch(printerId, async (newPrinterId, oldPrinterId) => {
   } else if (!newPrinterId) {
     fileList.value = undefined
   }
-})
-
-// URL <-> drawer state sync. We use the URL as the source of truth so reload,
-// bookmark, share-link, and browser back/forward all do the right thing.
-
-function parseRouteSidenav() {
-  // Number(undefined) -> NaN and Number(null) -> 0, both caught by `id > 0`
-  // and Number.isFinite below — no need for an explicit nullish branch.
-  const id = Number(route.query.sidenav)
-  const path = typeof route.query.path === 'string' ? route.query.path : ''
-  return {
-    id: Number.isFinite(id) && id > 0 ? id : undefined,
-    path,
-  }
-}
-
-function applyRouteToState() {
-  const { id, path } = parseRouteSidenav()
-  if (!id) {
-    if (printerId.value) fileExplorer.closeFileExplorer()
-    return
-  }
-  const printer = printersStore.printer(id)
-  // Printer not loaded yet (or deleted). For "not loaded yet" we'll retry once
-  // the store hydrates; for "deleted" we just leave the URL as-is on this tick
-  // and the next router change will eventually clear it.
-  if (!printer) return
-  // openFileExplorer resets currentPath when the printer changes — set the
-  // path AFTER opening so the URL's path survives the printer switch.
-  if (printerId.value !== id) fileExplorer.openFileExplorer(printer)
-  if (path !== currentPath.value) fileExplorer.setCurrentPath(path)
-}
-
-let suppressUrlWrite = false
-
-function writeStateToRoute() {
-  if (suppressUrlWrite) return
-  const query: Record<string, string | undefined> = { ...route.query } as any
-  if (printerId.value) {
-    query.sidenav = String(printerId.value)
-    query.path = currentPath.value || undefined
-  } else {
-    query.sidenav = undefined
-    query.path = undefined
-  }
-  // Skip the router call when nothing actually changed — prevents an infinite
-  // ping-pong with the route watcher below.
-  const sameSidenav = String(route.query.sidenav ?? '') === String(query.sidenav ?? '')
-  const samePath = String(route.query.path ?? '') === String(query.path ?? '')
-  if (sameSidenav && samePath) return
-  router.replace({ query })
-}
-
-// State changed (user opened/closed/navigated within drawer) → push to URL.
-watch([printerId, currentPath], writeStateToRoute)
-
-// Route changed externally (back/forward, manual edit, restore on mount) →
-// reflect into drawer state.
-watch(
-  () => [route.query.sidenav, route.query.path] as const,
-  () => {
-    suppressUrlWrite = true
-    applyRouteToState()
-    // Allow the writeStateToRoute watch to fire again on the next tick.
-    queueMicrotask(() => { suppressUrlWrite = false })
-  },
-)
-
-// The printer store loads asynchronously after mount, so an early restore can
-// fail with "printer doesn't exist yet". Re-attempt whenever the list grows.
-watch(
-  () => printersStore.printers.length,
-  () => applyRouteToState(),
-)
-
-onMounted(() => {
-  applyRouteToState()
 })
 
 function truncateProgress(progress?: number) {

--- a/src/components/Generic/FileExplorerSideNav.vue
+++ b/src/components/Generic/FileExplorerSideNav.vue
@@ -417,7 +417,8 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { generateInitials } from '@/shared/noun-adjectives.data'
 import { PrinterRemoteFileService, PrintersService } from '@/backend'
 import { PrinterMaintenanceLogService } from '@/backend/printer-maintenance-log.service'
@@ -445,6 +446,8 @@ interface TreeNode {
 const printersStore = usePrinterStore()
 const printerStateStore = usePrinterStateStore()
 const fileExplorer = useFileExplorer()
+const route = useRoute()
+const router = useRouter()
 
 const fileSearch = ref<string | undefined>(undefined)
 const fileList = ref<FileDto[] | undefined>(undefined)
@@ -579,6 +582,82 @@ watch(printerId, async (newPrinterId, oldPrinterId) => {
   } else if (!newPrinterId) {
     fileList.value = undefined
   }
+})
+
+// URL <-> drawer state sync. We use the URL as the source of truth so reload,
+// bookmark, share-link, and browser back/forward all do the right thing.
+
+function parseRouteSidenav() {
+  const idRaw = route.query.sidenav
+  const id = idRaw != null ? Number(idRaw) : NaN
+  const path = typeof route.query.path === 'string' ? route.query.path : ''
+  return {
+    id: Number.isFinite(id) && id > 0 ? id : undefined,
+    path,
+  }
+}
+
+function applyRouteToState() {
+  const { id, path } = parseRouteSidenav()
+  if (!id) {
+    if (printerId.value) fileExplorer.closeFileExplorer()
+    return
+  }
+  const printer = printersStore.printer(id)
+  // Printer not loaded yet (or deleted). For "not loaded yet" we'll retry once
+  // the store hydrates; for "deleted" we just leave the URL as-is on this tick
+  // and the next router change will eventually clear it.
+  if (!printer) return
+  // openFileExplorer resets currentPath when the printer changes — set the
+  // path AFTER opening so the URL's path survives the printer switch.
+  if (printerId.value !== id) fileExplorer.openFileExplorer(printer)
+  if (path !== currentPath.value) fileExplorer.setCurrentPath(path)
+}
+
+let suppressUrlWrite = false
+
+function writeStateToRoute() {
+  if (suppressUrlWrite) return
+  const query: Record<string, string | undefined> = { ...route.query } as any
+  if (printerId.value) {
+    query.sidenav = String(printerId.value)
+    query.path = currentPath.value || undefined
+  } else {
+    query.sidenav = undefined
+    query.path = undefined
+  }
+  // Skip the router call when nothing actually changed — prevents an infinite
+  // ping-pong with the route watcher below.
+  const sameSidenav = String(route.query.sidenav ?? '') === String(query.sidenav ?? '')
+  const samePath = String(route.query.path ?? '') === String(query.path ?? '')
+  if (sameSidenav && samePath) return
+  router.replace({ query })
+}
+
+// State changed (user opened/closed/navigated within drawer) → push to URL.
+watch([printerId, currentPath], writeStateToRoute)
+
+// Route changed externally (back/forward, manual edit, restore on mount) →
+// reflect into drawer state.
+watch(
+  () => [route.query.sidenav, route.query.path] as const,
+  () => {
+    suppressUrlWrite = true
+    applyRouteToState()
+    // Allow the writeStateToRoute watch to fire again on the next tick.
+    queueMicrotask(() => { suppressUrlWrite = false })
+  },
+)
+
+// The printer store loads asynchronously after mount, so an early restore can
+// fail with "printer doesn't exist yet". Re-attempt whenever the list grows.
+watch(
+  () => printersStore.printers.length,
+  () => applyRouteToState(),
+)
+
+onMounted(() => {
+  applyRouteToState()
 })
 
 function truncateProgress(progress?: number) {

--- a/src/shared/file-explorer-url-sync.composable.ts
+++ b/src/shared/file-explorer-url-sync.composable.ts
@@ -1,0 +1,89 @@
+import { onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useFileExplorer } from '@/shared/file-explorer.composable'
+import { usePrinterStore } from '@/store/printer.store'
+
+export function useFileExplorerUrlSync() {
+  const route = useRoute()
+  const router = useRouter()
+  const fileExplorer = useFileExplorer()
+  const printersStore = usePrinterStore()
+
+  function parseRoute() {
+    const id = Number(route.query.sidenav)
+    const path = typeof route.query.path === 'string' ? route.query.path : ''
+    return {
+      id: Number.isFinite(id) && id > 0 ? id : undefined,
+      path,
+    }
+  }
+
+  function applyRouteToState() {
+    const { id, path } = parseRoute()
+
+    if (!id) {
+      if (fileExplorer.currentPrinterId.value) {
+        fileExplorer.closeFileExplorer()
+      }
+      return
+    }
+
+    const printer = printersStore.printer(id)
+    if (!printer) {
+      return
+    }
+
+    if (fileExplorer.currentPrinterId.value !== id) {
+      fileExplorer.openFileExplorer(printer)
+    }
+
+    if (path !== fileExplorer.currentPath.value) {
+      fileExplorer.setCurrentPath(path)
+    }
+  }
+
+  let suppressUrlWrite = false
+
+  function writeStateToRoute() {
+    if (suppressUrlWrite) {
+      return
+    }
+
+    const query: Record<string, string | undefined> = { ...route.query } as any
+    if (fileExplorer.currentPrinterId.value) {
+      query.sidenav = String(fileExplorer.currentPrinterId.value)
+      query.path = fileExplorer.currentPath.value || undefined
+    } else {
+      query.sidenav = undefined
+      query.path = undefined
+    }
+
+    const sameSidenav = String(route.query.sidenav ?? '') === String(query.sidenav ?? '')
+    const samePath = String(route.query.path ?? '') === String(query.path ?? '')
+    if (sameSidenav && samePath) {
+      return
+    }
+
+    router.replace({ query })
+  }
+
+  watch(
+    [fileExplorer.currentPrinterId, fileExplorer.currentPath],
+    writeStateToRoute,
+  )
+
+  watch(
+    () => [route.query.sidenav, route.query.path] as const,
+    () => {
+      suppressUrlWrite = true
+      applyRouteToState()
+      queueMicrotask(() => {
+        suppressUrlWrite = false
+      })
+    },
+  )
+
+  watch(() => printersStore.printers.length, applyRouteToState)
+
+  onMounted(applyRouteToState)
+}

--- a/src/shared/file-explorer-url-sync.composable.ts
+++ b/src/shared/file-explorer-url-sync.composable.ts
@@ -76,14 +76,20 @@ export function useFileExplorerUrlSync() {
     () => [route.query.sidenav, route.query.path] as const,
     () => {
       suppressUrlWrite = true
-      applyRouteToState()
-      queueMicrotask(() => {
-        suppressUrlWrite = false
-      })
+      try {
+        applyRouteToState()
+      } finally {
+        queueMicrotask(() => {
+          suppressUrlWrite = false
+        })
+      }
     },
   )
 
-  watch(() => printersStore.printers.length, applyRouteToState)
+  watch(
+    () => printersStore.printers.map((p) => p.id).join(','),
+    applyRouteToState,
+  )
 
   onMounted(applyRouteToState)
 }


### PR DESCRIPTION
If the page reloaded with the file explorer drawer open, the state was lost — the drawer hides itself on mount and the user has to re-click the printer to get back to where they were. Same problem with browser back/forward and with sharing a "look at this printer's files" link.

Treat the URL as the source of truth: encode `?sidenav=<printerId>` and `?path=<currentDir>` whenever the drawer is open, restore them on mount, and reflect route changes (back/forward) back into drawer state. The two watchers are guarded with a microtask-scoped suppression flag so the state→URL and URL→state paths don't ping-pong.

If the printer ID in the URL doesn't match a known printer yet (still loading) we retry once the printer store hydrates; if it never matches (deleted) we leave the URL alone — opening any other printer will overwrite it cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## File Explorer Drawer State Persistence

The file explorer drawer (printer side navigation) now persists its open state and current path in the browser URL. This means:

- Reloading the page keeps the drawer open at the same printer and folder
- Browser back/forward navigation restores previous drawer states
- Shared links include the selected printer and folder so recipients see the same view

The URL encodes the drawer state so it acts as the source of truth; route changes and drawer interactions stay in sync for a more consistent navigation experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fdm-monster/fdm-monster-client-next/pull/1700)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1706
