### PR TITLE
Feature/sidenav file scroll

### DIFF
--- a/src/components/Generic/FileExplorerSideNav.vue
+++ b/src/components/Generic/FileExplorerSideNav.vue
@@ -737,6 +737,12 @@ function getTreeIcon(item: TreeNode) {
   display: flex;
   flex-direction: column;
   height: 100%;
+  /* Override Vuetify's default overflow-y: auto on the drawer content. With
+     a long file list (e.g. an SD card with hundreds of gcodes), the default
+     would let the entire drawer scroll as one block, so the inner file-list
+     never gets to use its own overflow:auto. Constrain the drawer to its
+     viewport height and let .file-list scroll inside. */
+  overflow: hidden;
 }
 
 .files-card {

--- a/src/components/Generic/FileExplorerSideNav.vue
+++ b/src/components/Generic/FileExplorerSideNav.vue
@@ -340,75 +340,79 @@
             </div>
           </div>
 
-          <!-- File List -->
-          <v-list
-            density="compact"
+          <!-- File List (virtualized so an SD card with hundreds of gcodes
+               stays responsive and the inner scroll is contained) -->
+          <v-virtual-scroll
+            :items="fileTree"
+            item-height="48"
             class="file-tree"
           >
-            <v-list-item
-              v-for="item in fileTree"
-              :key="item.id"
-              :class="{ 'cursor-pointer': item.type === 'folder' }"
-              @click="item.type === 'folder' ? navigateToDir(item.path) : undefined"
-            >
-              <template #prepend>
-                <v-icon
-                  :color="item.type === 'file' && item.file && isFileBeingPrinted(item.file) ? 'primary' : 'medium-emphasis'"
-                >
-                  {{ getTreeIcon(item) }}
-                </v-icon>
-              </template>
-
-              <v-list-item-title>
-                <div class="d-flex align-center">
-                  <span
-                    :class="{ 'text-primary font-weight-bold': item.type === 'file' && item.file && isFileBeingPrinted(item.file) }"
-                    class="text-body-2"
-                    :title="item.path"
+            <template #default="{ item }">
+              <v-list-item
+                :key="item.id"
+                density="compact"
+                :class="{ 'cursor-pointer': item.type === 'folder' }"
+                @click="item.type === 'folder' ? navigateToDir(item.path) : undefined"
+              >
+                <template #prepend>
+                  <v-icon
+                    :color="item.type === 'file' && item.file && isFileBeingPrinted(item.file) ? 'primary' : 'medium-emphasis'"
                   >
-                    {{ item.name }}
-                  </span>
-                  <span
+                    {{ getTreeIcon(item) }}
+                  </v-icon>
+                </template>
+
+                <v-list-item-title>
+                  <div class="d-flex align-center">
+                    <span
+                      :class="{ 'text-primary font-weight-bold': item.type === 'file' && item.file && isFileBeingPrinted(item.file) }"
+                      class="text-body-2"
+                      :title="item.path"
+                    >
+                      {{ item.name }}
+                    </span>
+                    <span
+                      v-if="item.type === 'file' && item.file"
+                      class="text-caption text-medium-emphasis ml-2"
+                    >
+                      {{ formatFileSize(item.file.size ?? undefined) }}
+                    </span>
+                  </div>
+                </v-list-item-title>
+
+                <template #append>
+                  <div
                     v-if="item.type === 'file' && item.file"
-                    class="text-caption text-medium-emphasis ml-2"
+                    class="d-flex ga-1"
+                    @click.stop
                   >
-                    {{ formatFileSize(item.file.size ?? undefined) }}
-                  </span>
-                </div>
-              </v-list-item-title>
-
-              <template #append>
-                <div
-                  v-if="item.type === 'file' && item.file"
-                  class="d-flex ga-1"
-                  @click.stop
-                >
-                  <v-btn
-                    icon="download"
-                    size="x-small"
-                    variant="text"
-                    @click="clickDownloadFile(item.file.path)"
-                  />
-                  <v-btn
-                    :disabled="isFileBeingPrinted(item.file)"
-                    icon="play_arrow"
-                    size="x-small"
-                    variant="text"
-                    color="success"
-                    @click="clickPrintFile(item.file)"
-                  />
-                  <v-btn
-                    :disabled="isFileBeingPrinted(item.file)"
-                    icon="delete"
-                    size="x-small"
-                    variant="text"
-                    color="error"
-                    @click="deleteFile(item.file)"
-                  />
-                </div>
-              </template>
-            </v-list-item>
-          </v-list>
+                    <v-btn
+                      icon="download"
+                      size="x-small"
+                      variant="text"
+                      @click="clickDownloadFile(item.file.path)"
+                    />
+                    <v-btn
+                      :disabled="isFileBeingPrinted(item.file)"
+                      icon="play_arrow"
+                      size="x-small"
+                      variant="text"
+                      color="success"
+                      @click="clickPrintFile(item.file)"
+                    />
+                    <v-btn
+                      :disabled="isFileBeingPrinted(item.file)"
+                      icon="delete"
+                      size="x-small"
+                      variant="text"
+                      color="error"
+                      @click="deleteFile(item.file)"
+                    />
+                  </div>
+                </template>
+              </v-list-item>
+            </template>
+          </v-virtual-scroll>
         </div>
       </v-card-text>
     </v-card>
@@ -783,9 +787,12 @@ function getTreeIcon(item: TreeNode) {
 }
 
 .file-list {
-  overflow-y: auto;
-  flex: 1 1 auto;
+  /* v-virtual-scroll manages its own scrolling; we just need a bounded box. */
+  overflow: hidden;
+  flex: 1 1 0;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .cursor-pointer {


### PR DESCRIPTION
## Summary

The printer side nav's file list became unusable when a printer had more than a screenful of files. With ~200+ gcodes on a printer SD card, the file list rendered past the viewport and there was no way to scroll to the entries off-screen.

Two related fixes, split across two commits so each can be reviewed independently:

### 1. `fix: contain drawer scroll so file list can scroll inside`

Vuetify's `.v-navigation-drawer__content` defaults to `overflow-y: auto`. The side nav's flex-column layout puts a `flex-grow` files card at the bottom, intending for its inner `.file-list` to be the only scroll surface — but the drawer's default overflow won out and the *whole drawer* scrolled as a single block. The inner scroll containers never got to do their job.

Setting `overflow: hidden` on the drawer content forces the layout to respect `height: 100%`, so flex children can bound themselves and the inner `.file-list` scroll takes over.

### 2. `perf: virtualize the file list`

A stock `<v-list v-for>` happily renders 235+ `<v-list-item>`s — both slow on open and a fight with the flex layout, because the v-list expands to its natural height and breaks any attempt to bound the surrounding scroller.

Switched to `<v-virtual-scroll>` with a fixed `item-height`. The same `<v-list-item>` markup moves into the slot — no behavioural change — but the DOM stays small and we get a deterministic, bounded scroll container as a side effect. The `.file-list` parent flips from `overflow-y: auto; flex: 1 1 auto` to `overflow: hidden; flex: 1 1 0` to just act as a bounded flex box.

## Test plan

- [x] Open a printer side nav for any printer with > 20 gcodes; verify the file list scrolls and the surrounding cards (header, quick actions, etc.) stay pinned.
- [x] Repeat with a printer that has *no* files — empty state still shows.
- [x] Repeat with a printer that has a file currently printing — "currently printing" highlight still applies.
- [x] Folder navigation still works (click folder → breadcrumb updates → scroll resets).
- [x] Download / print / delete row actions still respond (they're inside the virtualized slot, which can sometimes break event bubbling).

Tested against a real Duet running RepRapFirmware standalone with 235 gcodes on the SD card, also verified on a Bambu printer with much fewer files , but zoomed in enough and old behaviour = no scroll bar, new behaviour = yes scroll bar :)
