### PR TITLE
Feature/hide printer auth on edit

### DIFF
--- a/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
+++ b/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
@@ -108,6 +108,8 @@
               :counter="apiKeyRules.length"
               class="ma-1"
               type="password"
+              :placeholder="isUpdating ? '••••••••••••••••' : undefined"
+              :persistent-placeholder="isUpdating"
               :hint="isUpdating
                 ? 'Hidden for security — leave blank to keep the current value'
                 : 'User or Application Key with 32 or 43 characters (Global API key will fail)'"
@@ -131,6 +133,8 @@
               v-model="formData.password"
               class="ma-1"
               type="password"
+              :placeholder="isUpdating ? '••••••••••••••••' : undefined"
+              :persistent-placeholder="isUpdating"
               :hint="isUpdating
                 ? 'Hidden for security — leave blank to keep the current value'
                 : (formData.printerType === BambuType ? 'Access code from printer settings' : 'Password (visit your printer settings)')"

--- a/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
+++ b/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
@@ -107,14 +107,13 @@
               v-model="formData.apiKey"
               :counter="apiKeyRules.length"
               class="ma-1"
-              hint="User or Application Key with 32 or 43 characters (Global API key will fail)"
-              :label="
-                formData.printerType === OctoPrintType || formData.printerType === MoonrakerType
-                  ? 'API Key (required)*'
-                  : 'API Key (unsupported)'
-              "
+              type="password"
+              :hint="isUpdating
+                ? 'Hidden for security — leave blank to keep the current value'
+                : 'User or Application Key with 32 or 43 characters (Global API key will fail)'"
+              :label="isUpdating ? 'API Key (leave blank to keep)' : 'API Key (required)*'"
               persistent-hint
-              required
+              :required="!isUpdating"
             />
 
             <v-text-field
@@ -131,10 +130,15 @@
               v-if="formData.printerType === PrusaLinkType || formData.printerType === BambuType"
               v-model="formData.password"
               class="ma-1"
-              :hint="formData.printerType === BambuType ? 'Access code from printer settings' : 'Password (visit your printer settings)'"
-              :label="formData.printerType === BambuType ? 'AccessCode' : 'Password'"
+              type="password"
+              :hint="isUpdating
+                ? 'Hidden for security — leave blank to keep the current value'
+                : (formData.printerType === BambuType ? 'Access code from printer settings' : 'Password (visit your printer settings)')"
+              :label="isUpdating
+                ? (formData.printerType === BambuType ? 'AccessCode (leave blank to keep)' : 'Password (leave blank to keep)')
+                : (formData.printerType === BambuType ? 'AccessCode' : 'Password')"
               persistent-hint
-              required
+              :required="!isUpdating"
             />
           </v-col>
 
@@ -359,6 +363,10 @@ async function onDialogOpened() {
   const printer = printersStore.printer(printerId.value) as CreatePrinter;
   if (printer) {
     formData.value = PrintersService.convertPrinterToCreateForm(printer);
+    // Don't display existing credentials in the edit form. They're restored
+    // from the store at submit time if the user leaves the field blank.
+    formData.value.apiKey = "";
+    formData.value.password = "";
   }
 }
 
@@ -435,10 +443,14 @@ const isValid = () => {
   if (isMoonrakerType(form.printerType)) {
     return form.printerURL?.length && form.name?.length;
   }
+  // When editing, the apiKey/password fields may be left blank to keep the
+  // existing value — submit() will restore them from the store.
   if (isPrusaLinkType(form.printerType) || isBambuType(form.printerType)) {
-    return form.printerURL?.length && form.name?.length && form.username?.length && form.password?.length;
+    const passwordOk = form.password?.length || isUpdating.value;
+    return form.printerURL?.length && form.name?.length && form.username?.length && passwordOk;
   }
-  return form.printerURL?.length && form.name?.length && form.apiKey?.length;
+  const apiKeyOk = form.apiKey?.length || isUpdating.value;
+  return form.printerURL?.length && form.name?.length && apiKeyOk;
 };
 
 async function createPrinter(newPrinterData: CreatePrinter) {
@@ -485,6 +497,16 @@ async function submit() {
 
   if (isMoonrakerType(createdPrinter.printerType) || isPrusaLinkType(createdPrinter.printerType) || isBambuType(createdPrinter.printerType)) {
     createdPrinter.apiKey = "";
+  }
+
+  // On edit, a blank credential field means "keep current". Pull the existing
+  // value from the store before sending the update.
+  if (isUpdating.value && printerId.value) {
+    const existing = printersStore.printer(printerId.value);
+    if (existing) {
+      if (!createdPrinter.apiKey?.length) createdPrinter.apiKey = existing.apiKey ?? "";
+      if (!createdPrinter.password?.length) createdPrinter.password = existing.password ?? "";
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary

The "Update Printer" dialog rendered the OctoPrint API key and the PrusaLink password / Bambu access code in plain text inputs every time you opened it. Anyone with edit access could shoulder-surf the credentials, and the DOM exposed them to anything inspecting the page.

This PR blanks those fields on open and treats a blank value as "keep the current credential," so editing a printer no longer requires showing its secret. To make it clear that a credential *does* still exist server-side, the empty input shows a row of bullet characters as a persistent placeholder.

### Behavior

- **Update mode**:
  - `apiKey`, `password` open empty.
  - Placeholder shows `••••••••••••••••` so it's visually obvious there's a saved value (just hidden).
  - Label reads *"… (leave blank to keep)"*, hint reads *"Hidden for security — leave blank to keep the current value"*.
  - Inputs are `type="password"` so anything you type is also masked.
  - Required validation is relaxed for those fields.
  - On submit, any blank credential is rehydrated from the existing printer record before the PUT goes out.
- **Create mode**: unchanged — required fields with their normal hints, no placeholder bullets.
- Username / Serial: stays visible. PrusaLink's default is `maker` and Bambu's username is the serial printed on the device label; neither is secret.

### Out of scope

The server still ships these values down on `GET /printer/:id` so a determined user could fetch them via the API. That's a separate change — this PR addresses the most visible leak (the edit form) without server-side coordination.

## Test plan

- [ ] Edit an OctoPrint printer → API Key field is empty but shows bullet placeholder, masked, hint shows "leave blank to keep". Save without typing → printer still works.
- [ ] Edit again → typed new API Key → save → connection uses the new value.
- [ ] Edit a PrusaLink printer → Password is empty (placeholder bullets); Username (`maker`) is visible. Save blank → works.
- [ ] Edit a Bambu printer → AccessCode is empty (placeholder bullets); Serial is visible. Save blank → works.
- [ ] Create a new printer of each type → required fields enforced as before, no placeholder bullets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Printer Credential Security Improvement

**Fixed**: Printer credentials (API keys and passwords) are no longer displayed in the "Update Printer" dialog, preventing accidental exposure when editing existing printers.

**How it works**:
- When editing a printer, credential fields now appear empty with a visual indicator (bullet points) showing that a saved value exists
- Fields are labeled "(leave blank to keep)" with a hint explaining the security measure
- Credentials use masked input fields to prevent screen viewing
- Simply save without changes to retain existing credentials
- **Creating new printers remains unchanged** — credentials are still required and visible

**Affected printers**: OctoPrint (API Key), PrusaLink (Password), and Bambu Lab (Access Code) connections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fdm-monster/fdm-monster-client-next/pull/1703)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1708
