### PR TITLE
feat(dev): allow overriding the API base URL via VITE_API_BASE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE=http://localhost:4001

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-VITE_API_BASE=http://localhost:4001
+VITE_API_BASE=http://localhost:4000/

--- a/src/shared/http-client.ts
+++ b/src/shared/http-client.ts
@@ -11,6 +11,9 @@ import { captureException } from '@sentry/vue'
  * Made async for future possibility of getting base URI externally or asynchronously
  */
 export async function getBaseUri() {
+  // Override via .env.local: VITE_API_BASE=https://your-server.example/
+  const override = import.meta.env.VITE_API_BASE as string | undefined
+  if (override?.length) return override
   // return process.env.NODE_ENV === "development" ? "https://demo.fdm-monster.net" : "";
   return process.env.NODE_ENV === 'development' ? 'http://localhost:4000/' : '/' // Same-origin policy
 }

--- a/src/shared/http-client.ts
+++ b/src/shared/http-client.ts
@@ -1,21 +1,19 @@
-import axios, { AxiosError, AxiosRequestConfig, HttpStatusCode } from 'axios'
-import { useAuthStore } from '@/store/auth.store'
-import { useEventBus } from '@vueuse/core'
+import axios, { AxiosError, AxiosRequestConfig, HttpStatusCode } from "axios";
+import { useAuthStore } from "@/store/auth.store";
+import { useEventBus } from "@vueuse/core";
 import {
   convertAuthErrorReason,
-  PermissionDeniedEvent
-} from '@/shared/auth.constants'
-import { captureException } from '@sentry/vue'
+  PermissionDeniedEvent,
+} from "@/shared/auth.constants";
+import { captureException } from "@sentry/vue";
 
-/**
- * Made async for future possibility of getting base URI externally or asynchronously
- */
 export async function getBaseUri() {
-  // Override via .env.local: VITE_API_BASE=https://your-server.example/
-  const override = import.meta.env.VITE_API_BASE as string | undefined
-  if (override?.length) return override
-  // return process.env.NODE_ENV === "development" ? "https://demo.fdm-monster.net" : "";
-  return process.env.NODE_ENV === 'development' ? 'http://localhost:4000/' : '/' // Same-origin policy
+  const urlBaseOverride = import.meta.env.VITE_API_BASE as string | undefined;
+  if (urlBaseOverride?.length) {
+    return urlBaseOverride;
+  }
+
+  return process.env.NODE_ENV === "development" ? "http://localhost:4000/" : "/"; // Same-origin policy
 }
 
 export async function getHttpClient(


### PR DESCRIPTION
## Summary

`getBaseUri()` is hardcoded to `http://localhost:4000/` in development. That's the right default for the usual "server + client on the same laptop" setup, but unhelpful when you want to run the dev client against a remote backend — typically a real instance on your LAN to reproduce production-only state, or a teammate's box for diagnostic work.

This adds a single env override: if `VITE_API_BASE` is set, `getBaseUri()` returns it; otherwise behavior is exactly as before. The same value flows into Socket.IO since the gateway also calls `getBaseUri()`.

## Usage

Create a `.env.local` (already covered by `.gitignore`):

\`\`\`
VITE_API_BASE=http://my-server:4000/
\`\`\`

Restart Vite. The dev client at `localhost:3000` now talks REST + Socket.IO to the override URL. Unset → unchanged default.

## Test plan

- [ ] No `.env.local` → `npm run dev` → REST + sockets go to `localhost:4000` (current behavior).
- [ ] `VITE_API_BASE=http://192.168.x.x:4000/` → dev client talks to the LAN server end-to-end (login, printer list, live socket updates).
- [ ] Trailing slash is required (axios `baseURL` semantics).

-----

getBaseUri() was hardcoded to http://localhost:4000/ in development, which is the right default for the usual "server + client both on this laptop" setup but unhelpful when you want to run the dev client against a remote backend — typically a real instance on your LAN to reproduce production-only state, or a teammate's box for diagnostic work.

Honor an import.meta.env.VITE_API_BASE override before the default. Set it via a gitignored .env.local file (e.g. VITE_API_BASE=http://my-box:4000/) to point the dev client anywhere; leave it unset and behavior is exactly what it was. Same override flows into Socket.IO since the gateway also calls getBaseUri().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Development Quality of Life Improvement

**Configurable API Server URL**: During development you can now override the API server URL by setting VITE_API_BASE (for example, to point the dev client at a remote backend on your LAN). This affects both REST and Socket.IO connections.

How to use:
1. Create or edit a gitignored .env.local file
2. Add `VITE_API_BASE=http://your-server:4000/` (include the trailing slash)
3. Restart the Vite dev server

Behavior:
- If VITE_API_BASE is set, the dev client will use it for API and socket connections.
- If unset, existing behavior is preserved (localhost:4000 in development).

Also included: a .env.example documenting VITE_API_BASE.

Fixes #1705

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fdm-monster/fdm-monster-client-next/pull/1704)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1705
