### PR TITLE
Release v2.4.2

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,15 @@
 # fdm-monster-client-next release notes
 
+## Client 2.4.2
+
+Features
+
+- dev/staging instance badge in the navbar
+
+Chores
+
+- allow overriding the API base URL via VITE_API_BASE
+
 ## Client 2.4.1
 
 Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fdm-monster/client-next",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fdm-monster/fdm-monster-client-next.git"

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -263,6 +263,16 @@ if ($LASTEXITCODE -ne 0) {
 }
 Write-Success "Checked out $releaseBranch"
 
+# --- Stage any pre-existing uncommitted files ---------------------------------
+Write-Header "Staging uncommitted files"
+$dirtyFiles = git status --porcelain 2>&1 | Where-Object { $_ -match "^\s?[MADRCU?!]" }
+if ($dirtyFiles) {
+    $null = & git add -A
+    Write-Success "Staged all uncommitted changes"
+} else {
+    Write-Step "Nothing extra to stage"
+}
+
 # --- Commit -------------------------------------------------------------------
 Write-Header "Committing release files"
 if ($hasContent) {

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -223,8 +223,8 @@ if ($hasContent) {
 
     $newBlock = $lines -join "`n"
 
-    # Insert after the H1 heading
-    $rnContent = Get-Content $rnPath -Raw
+    # FIX: cast to [string] to release the read handle before writing back
+    $rnContent = [string](Get-Content $rnPath -Raw)
     $heading = "# fdm-monster-client-next release notes"
     if ($rnContent -notmatch [regex]::Escape($heading)) {
         Write-Warn "H1 heading not found in RELEASE_NOTES.md - prepending it."
@@ -239,7 +239,8 @@ if ($hasContent) {
 
 # --- Update package.json and yarn.lock ----------------------------------------
 Write-Header "Updating package.json and yarn.lock"
-$pkgRaw = Get-Content $pkgPath -Raw
+# FIX: cast to [string] to release the read handle before writing back
+$pkgRaw = [string](Get-Content $pkgPath -Raw)
 $pkgRaw = $pkgRaw -replace '"version"\s*:\s*"[^"]+"', "`"version`": `"$newVersion`""
 Set-Content -Path $pkgPath -Value $pkgRaw -NoNewline
 Write-Success "package.json updated"


### PR DESCRIPTION
## Release v2.4.2

### Recent Merges

- 2026-05-15  davidzwa  Merge pull request #1710 from raykholo/feature/dev-instance-badge -- feat(top-bar): dev/staging instance badge in the navbar
- 2026-05-14  davidzwa  Merge pull request #1704 from raykholo/feature/dev-qol-features -- feat(dev): allow overriding the API base URL via VITE_API_BASE
- 2026-05-14  davidzwa  Merge pull request #1702 from fdm-monster/release/2.4.1 -- Release v2.4.1
- 2026-05-14  davidzwa  Merge pull request #1701 from raykholo/feature/sidenav-file-scroll -- Feature/sidenav file scroll
- 2026-05-13  davidzwa  Merge pull request #1699 from fdm-monster/release/2.4.0 -- Releases Client 2.4.0
- 2026-05-13  davidzwa  Merge pull request #1684 from raykholo/feature/api-keys -- Feature/api keys
- 2026-05-13  davidzwa  Merge pull request #1697 from fdm-monster/all-contributors/add-raykholo -- docs: add raykholo as a contributor for code
- 2026-05-07  davidzwa  Merge pull request #1677 from fdm-monster/fix/enable-redirect-to-moonraker-ui -- fix: enable web interface redirect capability for moonraker
- 2026-02-01  davidzwa  Merge pull request #1510 from fdm-monster/fix/1509-files-page-id-shown-on-delete -- Shows filename when deleting files
- 2026-02-01  davidzwa  Merge pull request #1511 from fdm-monster/all-contributors/add-thatguy-jaysenodell -- docs: add thatguy-jaysenodell as a contributor for bug


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Release v2.4.2

## What's New

- Development & staging environment visibility: a badge in the navbar indicates when you’re connected to a dev or staging instance.
- Enhanced deployment flexibility: you can now override the API base URL via the VITE_API_BASE environment variable.
- File explorer improvements: refined scrolling behavior in the file navigator sidebar.

This release updates the package to v2.4.2 and adds the above notes to the release documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fdm-monster/fdm-monster-client-next/pull/1711)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->