### PR TITLE
feat(jobs): print-file routing UI

### DIFF
--- a/src/backend/routing.service.ts
+++ b/src/backend/routing.service.ts
@@ -18,13 +18,13 @@ export interface RoutingQueueResult {
 export class RoutingService extends BaseService {
   static async resolve(fileStorageId: string): Promise<RoutingResolution> {
     return this.get<RoutingResolution>(
-      ServerApi.resolveRoutingRoute(fileStorageId)
+      ServerApi.resolvePrintFileRoutingRoute(fileStorageId)
     )
   }
 
   static async queue(fileStorageId: string): Promise<RoutingQueueResult> {
     return this.post<RoutingQueueResult>(
-      ServerApi.queueRoutingRoute(fileStorageId),
+      ServerApi.queuePrintFileRoutingRoute(fileStorageId),
       {}
     )
   }

--- a/src/backend/routing.service.ts
+++ b/src/backend/routing.service.ts
@@ -3,7 +3,7 @@ import { ServerApi } from '@/backend/server.api'
 
 export interface RoutingResolution {
   routingTarget: string | null
-  kind: 'printer' | 'tag' | 'none'
+  kind: 'printer' | 'tag' | 'none' | 'ambiguous'
   matchedName: string | null
   printerIds: number[]
 }

--- a/src/backend/routing.service.ts
+++ b/src/backend/routing.service.ts
@@ -1,0 +1,31 @@
+import { BaseService } from '@/backend/base.service'
+import { ServerApi } from '@/backend/server.api'
+
+export interface RoutingResolution {
+  routingTarget: string | null
+  kind: 'printer' | 'tag' | 'none'
+  matchedName: string | null
+  printerIds: number[]
+}
+
+export interface RoutingQueueResult {
+  resolution: RoutingResolution
+  queued: boolean
+  jobId: number | null
+  printerId: number | null
+}
+
+export class RoutingService extends BaseService {
+  static async resolve(fileStorageId: string): Promise<RoutingResolution> {
+    return this.get<RoutingResolution>(
+      ServerApi.resolveRoutingRoute(fileStorageId)
+    )
+  }
+
+  static async queue(fileStorageId: string): Promise<RoutingQueueResult> {
+    return this.post<RoutingQueueResult>(
+      ServerApi.queueRoutingRoute(fileStorageId),
+      {}
+    )
+  }
+}

--- a/src/backend/server.api.ts
+++ b/src/backend/server.api.ts
@@ -37,6 +37,12 @@ export class ServerApi {
   static readonly apiKeysRoute = `${ServerApi.base}/api-keys`
   static readonly apiKeyRoute = (id: number) => `${ServerApi.apiKeysRoute}/${id}`
 
+  static readonly routingRoute = `${ServerApi.base}/routing`
+  static readonly resolveRoutingRoute = (fileStorageId: string) =>
+    `${ServerApi.routingRoute}/resolve/${fileStorageId}`
+  static readonly queueRoutingRoute = (fileStorageId: string) =>
+    `${ServerApi.routingRoute}/queue/${fileStorageId}`
+
   static readonly deleteTagRoute = (id: number) => `${ServerApi.base}/printer-tag/${id}`
 
   static readonly updateTagNameRoute = (id: number) =>

--- a/src/backend/server.api.ts
+++ b/src/backend/server.api.ts
@@ -37,11 +37,11 @@ export class ServerApi {
   static readonly apiKeysRoute = `${ServerApi.base}/api-keys`
   static readonly apiKeyRoute = (id: number) => `${ServerApi.apiKeysRoute}/${id}`
 
-  static readonly routingRoute = `${ServerApi.base}/routing`
-  static readonly resolveRoutingRoute = (fileStorageId: string) =>
-    `${ServerApi.routingRoute}/resolve/${fileStorageId}`
-  static readonly queueRoutingRoute = (fileStorageId: string) =>
-    `${ServerApi.routingRoute}/queue/${fileStorageId}`
+  static readonly printFileRoutingRoute = `${ServerApi.base}/print-file-routing`
+  static readonly resolvePrintFileRoutingRoute = (fileStorageId: string) =>
+    `${ServerApi.printFileRoutingRoute}/resolve/${fileStorageId}`
+  static readonly queuePrintFileRoutingRoute = (fileStorageId: string) =>
+    `${ServerApi.printFileRoutingRoute}/queue/${fileStorageId}`
 
   static readonly deleteTagRoute = (id: number) => `${ServerApi.base}/printer-tag/${id}`
 

--- a/src/components/Files/FilesView.vue
+++ b/src/components/Files/FilesView.vue
@@ -301,6 +301,21 @@
               </v-tooltip>
             </v-btn>
             <v-btn
+              icon="alt_route"
+              size="small"
+              variant="text"
+              color="primary"
+              @click="openRoutingDialog(item)"
+            >
+              <v-icon>alt_route</v-icon>
+              <v-tooltip
+                activator="parent"
+                location="top"
+              >
+                Resolve routing
+              </v-tooltip>
+            </v-btn>
+            <v-btn
               icon="analytics"
               size="small"
               variant="text"
@@ -360,6 +375,11 @@
       v-model="queueDialog"
       :file="selectedFileForQueue"
     />
+
+    <PrintFileRoutingDialog
+      v-model="routingDialog"
+      :file="selectedFileForRouting"
+    />
   </v-container>
 </template>
 
@@ -376,6 +396,7 @@ import { formatDate, formatRelativeTime, formatDuration } from '@/utils/date-tim
 import { getPrinterTypeLogo } from '@/shared/printer-types.constants'
 import FileDetailsDialog from './FileDetailsDialog.vue'
 import QueueFileDialog from './QueueFileDialog.vue'
+import PrintFileRoutingDialog from './PrintFileRoutingDialog.vue'
 
 const snackbar = useSnackbar()
 const printerStore = usePrinterStore()
@@ -387,6 +408,8 @@ const detailsDialog = ref(false)
 const selectedFile = ref<FileMetadata | null>(null)
 const queueDialog = ref(false)
 const selectedFileForQueue = ref<FileMetadata | null>(null)
+const routingDialog = ref(false)
+const selectedFileForRouting = ref<FileMetadata | null>(null)
 const uploading = ref(false)
 const isDragging = ref(false)
 const dragDepth = ref(0)
@@ -446,6 +469,11 @@ const loadFiles = async () => {
 const viewFile = (file: FileMetadata) => {
   selectedFile.value = file
   detailsDialog.value = true
+}
+
+const openRoutingDialog = (file: FileMetadata) => {
+  selectedFileForRouting.value = file
+  routingDialog.value = true
 }
 
 const deleteFile = async (file: FileMetadata) => {

--- a/src/components/Files/PrintFileRoutingDialog.vue
+++ b/src/components/Files/PrintFileRoutingDialog.vue
@@ -130,24 +130,33 @@ const invalidateGlobalQueue = useInvalidateGlobalQueue()
 const loading = ref(false)
 const queuing = ref(false)
 const resolution = ref<RoutingResolution | null>(null)
+// Bumped on every open/close so a slow resolve cannot overwrite newer state
+let resolveRequestId = 0
 
 const canQueue = computed(() => resolution.value?.printerIds.length === 1)
 
 watch(
   () => props.modelValue,
   async (isOpen) => {
+    const requestId = ++resolveRequestId
     if (!isOpen || !props.file) {
       return
     }
     resolution.value = null
     loading.value = true
     try {
-      resolution.value = await RoutingService.resolve(props.file.fileStorageId)
+      const resolved = await RoutingService.resolve(props.file.fileStorageId)
+      if (requestId !== resolveRequestId) {
+        return
+      }
+      resolution.value = resolved
     } catch (error) {
       console.error('Failed to resolve routing:', error)
       snackbar.error('Failed to resolve routing')
     } finally {
-      loading.value = false
+      if (requestId === resolveRequestId) {
+        loading.value = false
+      }
     }
   }
 )

--- a/src/components/Files/PrintFileRoutingDialog.vue
+++ b/src/components/Files/PrintFileRoutingDialog.vue
@@ -45,6 +45,15 @@
           </v-alert>
 
           <v-alert
+            v-else-if="resolution.kind === 'ambiguous'"
+            type="warning"
+            variant="tonal"
+          >
+            Routing target "{{ resolution.routingTarget }}" matches both a
+            printer and a tag — assign this file manually.
+          </v-alert>
+
+          <v-alert
             v-else
             type="info"
             variant="tonal"

--- a/src/components/Files/PrintFileRoutingDialog.vue
+++ b/src/components/Files/PrintFileRoutingDialog.vue
@@ -1,0 +1,168 @@
+<template>
+  <v-dialog
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
+    max-width="600"
+  >
+    <v-card v-if="file">
+      <v-card-title class="d-flex align-center">
+        <v-icon class="mr-2">alt_route</v-icon>
+        Resolve Routing
+        <v-spacer />
+        <v-btn
+          icon="close"
+          variant="text"
+          @click="$emit('update:modelValue', false)"
+        />
+      </v-card-title>
+
+      <v-card-text>
+        <div class="mb-4">
+          <strong>File:</strong>
+          {{ file.metadata?._originalFileName || file.fileName }}
+        </div>
+
+        <div
+          v-if="loading"
+          class="d-flex justify-center my-4"
+        >
+          <v-progress-circular indeterminate />
+        </div>
+
+        <template v-else-if="resolution">
+          <v-alert
+            v-if="resolution.kind === 'none'"
+            type="warning"
+            variant="tonal"
+          >
+            <template v-if="resolution.routingTarget">
+              Routing target "{{ resolution.routingTarget }}" matched no printer
+              or tag — assign this file manually.
+            </template>
+            <template v-else>
+              This file has no routing target — assign it to a printer manually.
+            </template>
+          </v-alert>
+
+          <v-alert
+            v-else
+            type="info"
+            variant="tonal"
+          >
+            Routing target
+            <strong>{{ resolution.routingTarget }}</strong> resolves to
+            {{ resolution.kind }}
+            <strong>{{ resolution.matchedName }}</strong> ({{
+              resolution.printerIds.length
+            }}
+            printer(s)).
+          </v-alert>
+
+          <v-alert
+            v-if="resolution.printerIds.length > 1"
+            type="info"
+            variant="tonal"
+            class="mt-3"
+          >
+            Several printers match — auto-queue is skipped; pick one manually.
+          </v-alert>
+        </template>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          color="grey"
+          variant="text"
+          @click="$emit('update:modelValue', false)"
+        >
+          Close
+        </v-btn>
+        <v-btn
+          color="primary"
+          variant="elevated"
+          :disabled="!canQueue"
+          :loading="queuing"
+          @click="queueFile"
+        >
+          Queue
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed, watch } from 'vue'
+import type { FileMetadata } from '@/backend/file-storage.service'
+import {
+  RoutingService,
+  type RoutingResolution
+} from '@/backend/routing.service'
+import { useSnackbar } from '@/shared/snackbar.composable'
+import { useInvalidateGlobalQueue } from '@/queries/global-queue.query'
+
+interface Props {
+  modelValue: boolean
+  file: FileMetadata | null
+}
+
+interface Emits {
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'queued'): void
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const snackbar = useSnackbar()
+const invalidateGlobalQueue = useInvalidateGlobalQueue()
+
+const loading = ref(false)
+const queuing = ref(false)
+const resolution = ref<RoutingResolution | null>(null)
+
+const canQueue = computed(() => resolution.value?.printerIds.length === 1)
+
+watch(
+  () => props.modelValue,
+  async (isOpen) => {
+    if (!isOpen || !props.file) {
+      return
+    }
+    resolution.value = null
+    loading.value = true
+    try {
+      resolution.value = await RoutingService.resolve(props.file.fileStorageId)
+    } catch (error) {
+      console.error('Failed to resolve routing:', error)
+      snackbar.error('Failed to resolve routing')
+    } finally {
+      loading.value = false
+    }
+  }
+)
+
+const queueFile = async () => {
+  if (!props.file) {
+    return
+  }
+  queuing.value = true
+  try {
+    const result = await RoutingService.queue(props.file.fileStorageId)
+    if (result.queued) {
+      snackbar.info('File queued via routing')
+      await invalidateGlobalQueue()
+      emit('queued')
+      emit('update:modelValue', false)
+    } else {
+      snackbar.error('File could not be auto-queued')
+    }
+  } catch (error) {
+    console.error('Failed to queue file:', error)
+    snackbar.error('Failed to queue file')
+  } finally {
+    queuing.value = false
+  }
+}
+</script>

--- a/src/components/PrintJobs/PrintJobs.vue
+++ b/src/components/PrintJobs/PrintJobs.vue
@@ -918,7 +918,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted, ref, computed, watch } from 'vue'
+import { onMounted, onBeforeUnmount, ref, computed, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { PrintJobService, type PrintJobDto, type PrintJobSearchPagedParams } from '@/backend/print-job.service'
 import { PrintQueueService } from '@/backend/print-queue.service'
@@ -1199,6 +1199,10 @@ const debouncedSearch = useDebounceFn(() => {
   loadPrintJobs()
 }, 500)
 
+// Poll the queue tab so routed/added jobs show up without a manual refresh
+const queuePollIntervalMs = 5000
+let queuePollTimer: number | undefined
+
 onMounted(async () => {
   // Load printers first
   await printerStore.loadPrinters()
@@ -1212,6 +1216,18 @@ onMounted(async () => {
 
   await loadPrintJobs()
   await loadTags()
+
+  queuePollTimer = window.setInterval(() => {
+    if (activeTab.value === 'queue' && !loadingQueue.value) {
+      loadQueue(true)
+    }
+  }, queuePollIntervalMs)
+})
+
+onBeforeUnmount(() => {
+  if (queuePollTimer !== undefined) {
+    window.clearInterval(queuePollTimer)
+  }
 })
 
 const loadPrintJobs = async () => {
@@ -1253,18 +1269,25 @@ const loadPrintJobs = async () => {
 }
 
 // Queue functions
-const loadQueue = async () => {
-  loadingQueue.value = true
+const loadQueue = async (silent = false) => {
+  if (!silent) {
+    loadingQueue.value = true
+  }
   try {
     const response = await PrintQueueService.getGlobalQueue(queueCurrentPage.value, queuePageSize.value)
     queueItems.value = response.items
     queueCount.value = response.totalCount
   } catch (error) {
     console.error('Failed to load queue:', error)
-    queueItems.value = []
-    queueCount.value = 0
+    // A transient poll failure should not blank the table the user is looking at
+    if (!silent) {
+      queueItems.value = []
+      queueCount.value = 0
+    }
   } finally {
-    loadingQueue.value = false
+    if (!silent) {
+      loadingQueue.value = false
+    }
   }
 }
 

--- a/src/components/PrintJobs/PrintJobs.vue
+++ b/src/components/PrintJobs/PrintJobs.vue
@@ -1201,7 +1201,9 @@ const debouncedSearch = useDebounceFn(() => {
 
 // Poll the queue tab so routed/added jobs show up without a manual refresh
 const queuePollIntervalMs = 5000
-let queuePollTimer: number | undefined
+let queuePollTimer: ReturnType<typeof setInterval> | undefined
+// Tracked separately from loadingQueue so a slow silent poll cannot stack
+let loadingQueueSilent = false
 
 onMounted(async () => {
   // Load printers first
@@ -1217,8 +1219,8 @@ onMounted(async () => {
   await loadPrintJobs()
   await loadTags()
 
-  queuePollTimer = window.setInterval(() => {
-    if (activeTab.value === 'queue' && !loadingQueue.value) {
+  queuePollTimer = globalThis.setInterval(() => {
+    if (activeTab.value === 'queue' && !loadingQueue.value && !loadingQueueSilent) {
       loadQueue(true)
     }
   }, queuePollIntervalMs)
@@ -1226,7 +1228,7 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   if (queuePollTimer !== undefined) {
-    window.clearInterval(queuePollTimer)
+    globalThis.clearInterval(queuePollTimer)
   }
 })
 
@@ -1272,6 +1274,8 @@ const loadPrintJobs = async () => {
 const loadQueue = async (silent = false) => {
   if (!silent) {
     loadingQueue.value = true
+  } else {
+    loadingQueueSilent = true
   }
   try {
     const response = await PrintQueueService.getGlobalQueue(queueCurrentPage.value, queuePageSize.value)
@@ -1287,6 +1291,8 @@ const loadQueue = async (silent = false) => {
   } finally {
     if (!silent) {
       loadingQueue.value = false
+    } else {
+      loadingQueueSilent = false
     }
   }
 }

--- a/src/components/PrintJobs/PrintJobsView.vue
+++ b/src/components/PrintJobs/PrintJobsView.vue
@@ -1,5 +1,6 @@
 <template>
   <v-container fluid class="pa-0">
+    <UnassignedJobsPanel />
     <PrintJobs />
   </v-container>
 </template>
@@ -7,9 +8,10 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import PrintJobs from '@/components/PrintJobs/PrintJobs.vue'
+import UnassignedJobsPanel from '@/components/PrintJobs/UnassignedJobsPanel.vue'
 
 export default defineComponent({
   name: 'PrintJobsView',
-  components: { PrintJobs }
+  components: { PrintJobs, UnassignedJobsPanel }
 })
 </script>

--- a/src/components/PrintJobs/RouteJobDialog.vue
+++ b/src/components/PrintJobs/RouteJobDialog.vue
@@ -56,18 +56,20 @@
             No matching routing target — pick any printer to queue it on.
           </v-alert>
 
-          <v-radio-group
+          <v-autocomplete
             v-if="candidatePrinters.length"
             v-model="selectedPrinterId"
+            :items="candidatePrinters"
+            item-title="name"
+            item-value="id"
+            label="Pick a printer"
+            prepend-inner-icon="search"
+            variant="outlined"
+            density="compact"
+            autofocus
             hide-details
-          >
-            <v-radio
-              v-for="printer in candidatePrinters"
-              :key="printer.id"
-              :label="printer.name"
-              :value="printer.id"
-            />
-          </v-radio-group>
+            auto-select-first
+          />
           <v-alert
             v-else
             type="error"

--- a/src/components/PrintJobs/RouteJobDialog.vue
+++ b/src/components/PrintJobs/RouteJobDialog.vue
@@ -39,6 +39,15 @@
             of its {{ candidatePrinters.length }} printer(s) to queue it on.
           </v-alert>
           <v-alert
+            v-else-if="resolution && resolution.kind === 'ambiguous'"
+            type="warning"
+            variant="tonal"
+            class="mb-4"
+          >
+            <strong>{{ resolution.routingTarget }}</strong> matches both a printer
+            and a tag — pick the printer you want to queue it on.
+          </v-alert>
+          <v-alert
             v-else
             type="warning"
             variant="tonal"

--- a/src/components/PrintJobs/RouteJobDialog.vue
+++ b/src/components/PrintJobs/RouteJobDialog.vue
@@ -1,0 +1,179 @@
+<template>
+  <v-dialog
+    :model-value="modelValue"
+    max-width="560"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
+    <v-card v-if="job">
+      <v-card-title class="d-flex align-center">
+        <v-icon class="mr-2">alt_route</v-icon>
+        Route to printer
+        <v-spacer />
+        <v-btn
+          icon="close"
+          variant="text"
+          @click="$emit('update:modelValue', false)"
+        />
+      </v-card-title>
+
+      <v-card-text>
+        <div class="mb-4">
+          <strong>File:</strong> {{ job.fileName }}
+        </div>
+
+        <div
+          v-if="loading"
+          class="d-flex justify-center my-4"
+        >
+          <v-progress-circular indeterminate />
+        </div>
+
+        <template v-else>
+          <v-alert
+            v-if="resolution && resolution.kind === 'tag'"
+            type="info"
+            variant="tonal"
+            class="mb-4"
+          >
+            Targets tag <strong>{{ resolution.matchedName }}</strong> — pick one
+            of its {{ candidatePrinters.length }} printer(s) to queue it on.
+          </v-alert>
+          <v-alert
+            v-else
+            type="warning"
+            variant="tonal"
+            class="mb-4"
+          >
+            No matching routing target — pick any printer to queue it on.
+          </v-alert>
+
+          <v-radio-group
+            v-if="candidatePrinters.length"
+            v-model="selectedPrinterId"
+            hide-details
+          >
+            <v-radio
+              v-for="printer in candidatePrinters"
+              :key="printer.id"
+              :label="printer.name"
+              :value="printer.id"
+            />
+          </v-radio-group>
+          <v-alert
+            v-else
+            type="error"
+            variant="tonal"
+          >
+            No printers available to route to.
+          </v-alert>
+        </template>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          color="grey"
+          variant="text"
+          @click="$emit('update:modelValue', false)"
+        >
+          Cancel
+        </v-btn>
+        <v-btn
+          color="primary"
+          variant="elevated"
+          :disabled="selectedPrinterId === null"
+          :loading="routing"
+          @click="routeJob"
+        >
+          Route
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed, watch } from 'vue'
+import {
+  RoutingService,
+  type RoutingResolution
+} from '@/backend/routing.service'
+import { PrintQueueService } from '@/backend/print-queue.service'
+import type { PrintJobDto } from '@/backend/print-job.service'
+import { usePrinterStore } from '@/store/printer.store'
+import { useSnackbar } from '@/shared/snackbar.composable'
+import { useInvalidateGlobalQueue } from '@/queries/global-queue.query'
+
+interface Props {
+  modelValue: boolean
+  job: PrintJobDto | null
+}
+
+interface Emits {
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'routed'): void
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const printerStore = usePrinterStore()
+const snackbar = useSnackbar()
+const invalidateGlobalQueue = useInvalidateGlobalQueue()
+
+const loading = ref(false)
+const routing = ref(false)
+const resolution = ref<RoutingResolution | null>(null)
+const selectedPrinterId = ref<number | null>(null)
+
+// A tag resolves to its member printers; an unmatched file can go anywhere
+const candidatePrinters = computed(() => {
+  const ids = resolution.value?.printerIds ?? []
+  const pool = ids.length
+    ? printerStore.printers.filter((p) => ids.includes(p.id))
+    : printerStore.printers
+  return pool.map((p) => ({ id: p.id, name: p.name || `Printer #${p.id}` }))
+})
+
+watch(
+  () => props.modelValue,
+  async (isOpen) => {
+    if (!isOpen || !props.job) {
+      return
+    }
+    resolution.value = null
+    selectedPrinterId.value = null
+    if (!props.job.fileStorageId) {
+      return
+    }
+    loading.value = true
+    try {
+      resolution.value = await RoutingService.resolve(props.job.fileStorageId)
+    } catch (error) {
+      console.error('Failed to resolve routing:', error)
+      snackbar.error('Failed to resolve routing')
+    } finally {
+      loading.value = false
+    }
+  }
+)
+
+const routeJob = async () => {
+  if (!props.job || selectedPrinterId.value === null) {
+    return
+  }
+  routing.value = true
+  try {
+    await PrintQueueService.addToQueue(selectedPrinterId.value, props.job.id)
+    snackbar.info('File routed and queued')
+    await invalidateGlobalQueue()
+    emit('routed')
+    emit('update:modelValue', false)
+  } catch (error) {
+    console.error('Failed to route job:', error)
+    snackbar.error('Failed to route job to printer')
+  } finally {
+    routing.value = false
+  }
+}
+</script>

--- a/src/components/PrintJobs/RouteJobDialog.vue
+++ b/src/components/PrintJobs/RouteJobDialog.vue
@@ -134,6 +134,8 @@ const loading = ref(false)
 const routing = ref(false)
 const resolution = ref<RoutingResolution | null>(null)
 const selectedPrinterId = ref<number | null>(null)
+// Bumped on every open/close so a slow resolve cannot overwrite newer state
+let resolveRequestId = 0
 
 // A tag resolves to its member printers; an unmatched file can go anywhere
 const candidatePrinters = computed(() => {
@@ -147,6 +149,7 @@ const candidatePrinters = computed(() => {
 watch(
   () => props.modelValue,
   async (isOpen) => {
+    const requestId = ++resolveRequestId
     if (!isOpen || !props.job) {
       return
     }
@@ -157,12 +160,18 @@ watch(
     }
     loading.value = true
     try {
-      resolution.value = await RoutingService.resolve(props.job.fileStorageId)
+      const resolved = await RoutingService.resolve(props.job.fileStorageId)
+      if (requestId !== resolveRequestId) {
+        return
+      }
+      resolution.value = resolved
     } catch (error) {
       console.error('Failed to resolve routing:', error)
       snackbar.error('Failed to resolve routing')
     } finally {
-      loading.value = false
+      if (requestId === resolveRequestId) {
+        loading.value = false
+      }
     }
   }
 )

--- a/src/components/PrintJobs/UnassignedJobsPanel.vue
+++ b/src/components/PrintJobs/UnassignedJobsPanel.vue
@@ -8,6 +8,30 @@
     <v-card-title class="d-flex align-center text-body-1">
       <v-icon class="mr-2">alt_route</v-icon>
       {{ unassignedJobs.length }} file(s) awaiting printer assignment
+      <v-spacer />
+      <v-btn
+        v-if="someSelected"
+        color="warning"
+        variant="text"
+        size="small"
+        prepend-icon="checklist"
+        class="mr-1"
+        :loading="dismissing"
+        @click="openDismissConfirm([...selectedIds])"
+      >
+        Dismiss selected ({{ selectedIds.size }})
+      </v-btn>
+      <v-btn
+        v-if="unassignedJobs.length > 1"
+        color="warning"
+        variant="text"
+        size="small"
+        prepend-icon="delete_sweep"
+        :loading="dismissing"
+        @click="openDismissConfirm(unassignedJobs.map((j) => j.id))"
+      >
+        Dismiss all
+      </v-btn>
     </v-card-title>
 
     <v-list
@@ -18,6 +42,13 @@
         v-for="job in unassignedJobs"
         :key="job.id"
       >
+        <template #prepend>
+          <v-checkbox-btn
+            :model-value="selectedIds.has(job.id)"
+            density="compact"
+            @update:model-value="toggleSelect(job.id)"
+          />
+        </template>
         <v-list-item-title>{{ job.fileName }}</v-list-item-title>
         <v-list-item-subtitle v-if="job.statusReason">
           {{ job.statusReason }}
@@ -31,10 +62,19 @@
             variant="elevated"
             size="small"
             prepend-icon="alt_route"
+            class="mr-2"
             @click="openRouteDialog(job)"
           >
             Route…
           </v-btn>
+          <v-btn
+            icon="close"
+            variant="text"
+            size="small"
+            title="Dismiss"
+            :disabled="dismissing"
+            @click="dismissJob(job)"
+          />
         </template>
       </v-list-item>
     </v-list>
@@ -44,14 +84,47 @@
       :job="activeJob"
       @routed="refetch"
     />
+
+    <v-dialog
+      v-model="confirmDismissOpen"
+      max-width="420"
+    >
+      <v-card>
+        <v-card-title>Dismiss {{ pendingDismissIds.length }} unrouted file(s)?</v-card-title>
+        <v-card-text>
+          The PENDING job records will be removed. The files stay in storage and
+          can still be queued from the Files page.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            variant="text"
+            @click="confirmDismissOpen = false"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            color="warning"
+            variant="elevated"
+            :loading="dismissing"
+            @click="confirmDismiss"
+          >
+            Dismiss
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-card>
 </template>
 
 <script lang="ts" setup>
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useQuery } from '@tanstack/vue-query'
 import { PrintJobService, type PrintJobDto } from '@/backend/print-job.service'
 import RouteJobDialog from '@/components/PrintJobs/RouteJobDialog.vue'
+import { useSnackbar } from '@/shared/snackbar.composable'
+
+const snackbar = useSnackbar()
 
 const { data, refetch } = useQuery({
   queryKey: ['unassigned-print-jobs'],
@@ -60,7 +133,6 @@ const { data, refetch } = useQuery({
   refetchInterval: 1000 * 30
 })
 
-// The server creates a printer-less PENDING job for ambiguous/unmatched imports
 const unassignedJobs = computed<PrintJobDto[]>(() =>
   (data.value ?? []).filter(
     (job) => job.printerId === null && job.status === 'PENDING'
@@ -69,12 +141,82 @@ const unassignedJobs = computed<PrintJobDto[]>(() =>
 
 const dialogOpen = ref(false)
 const activeJob = ref<PrintJobDto | null>(null)
+const confirmDismissOpen = ref(false)
+const pendingDismissIds = ref<number[]>([])
+const dismissing = ref(false)
+const selectedIds = ref<Set<number>>(new Set())
+
+const someSelected = computed(() => selectedIds.value.size > 0)
+
+// Drop selections that no longer correspond to a visible unassigned job
+watch(unassignedJobs, (jobs) => {
+  if (!selectedIds.value.size) return
+  const liveIds = new Set(jobs.map((j) => j.id))
+  for (const id of selectedIds.value) {
+    if (!liveIds.has(id)) selectedIds.value.delete(id)
+  }
+})
 
 const routingTargetOf = (job: PrintJobDto) =>
   (job.metadata as { routingTarget?: string } | null)?.routingTarget ?? null
 
+const toggleSelect = (id: number) => {
+  if (selectedIds.value.has(id)) selectedIds.value.delete(id)
+  else selectedIds.value.add(id)
+  // Force reactivity on Set mutations
+  selectedIds.value = new Set(selectedIds.value)
+}
+
 const openRouteDialog = (job: PrintJobDto) => {
   activeJob.value = job
   dialogOpen.value = true
+}
+
+const openDismissConfirm = (ids: number[]) => {
+  pendingDismissIds.value = ids
+  confirmDismissOpen.value = true
+}
+
+const dismissJob = async (job: PrintJobDto) => {
+  if (dismissing.value) return
+  dismissing.value = true
+  try {
+    await PrintJobService.deleteJob(job.id)
+    snackbar.info('Dismissed')
+    await refetch()
+  } catch (error) {
+    console.error('Failed to dismiss job:', error)
+    snackbar.error('Failed to dismiss')
+  } finally {
+    dismissing.value = false
+  }
+}
+
+const confirmDismiss = async () => {
+  if (dismissing.value || pendingDismissIds.value.length === 0) return
+  dismissing.value = true
+  const ids = [...pendingDismissIds.value]
+  try {
+    const results = await Promise.allSettled(
+      ids.map((id) => PrintJobService.deleteJob(id))
+    )
+    const failed = results.filter((r) => r.status === 'rejected').length
+    results.forEach((r, idx) => {
+      if (r.status === 'fulfilled') selectedIds.value.delete(ids[idx])
+    })
+    selectedIds.value = new Set(selectedIds.value)
+    if (failed) {
+      snackbar.error(`Dismissed ${ids.length - failed} of ${ids.length} — ${failed} failed`)
+    } else {
+      snackbar.info(`Dismissed ${ids.length} file(s)`)
+    }
+    confirmDismissOpen.value = false
+    await refetch()
+  } catch (error) {
+    console.error('Failed to dismiss:', error)
+    snackbar.error('Failed to dismiss')
+  } finally {
+    dismissing.value = false
+  }
 }
 </script>

--- a/src/components/PrintJobs/UnassignedJobsPanel.vue
+++ b/src/components/PrintJobs/UnassignedJobsPanel.vue
@@ -1,0 +1,77 @@
+<template>
+  <v-card
+    v-if="unassignedJobs.length"
+    class="ma-4"
+    variant="tonal"
+    color="warning"
+  >
+    <v-card-title class="d-flex align-center text-body-1">
+      <v-icon class="mr-2">alt_route</v-icon>
+      {{ unassignedJobs.length }} file(s) awaiting printer assignment
+    </v-card-title>
+
+    <v-list
+      bg-color="transparent"
+      density="compact"
+    >
+      <v-list-item
+        v-for="job in unassignedJobs"
+        :key="job.id"
+      >
+        <v-list-item-title>{{ job.fileName }}</v-list-item-title>
+        <v-list-item-subtitle v-if="routingTargetOf(job)">
+          routing target: {{ routingTargetOf(job) }}
+        </v-list-item-subtitle>
+        <template #append>
+          <v-btn
+            color="primary"
+            variant="elevated"
+            size="small"
+            prepend-icon="alt_route"
+            @click="openRouteDialog(job)"
+          >
+            Route…
+          </v-btn>
+        </template>
+      </v-list-item>
+    </v-list>
+
+    <RouteJobDialog
+      v-model="dialogOpen"
+      :job="activeJob"
+      @routed="refetch"
+    />
+  </v-card>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed } from 'vue'
+import { useQuery } from '@tanstack/vue-query'
+import { PrintJobService, type PrintJobDto } from '@/backend/print-job.service'
+import RouteJobDialog from '@/components/PrintJobs/RouteJobDialog.vue'
+
+const { data, refetch } = useQuery({
+  queryKey: ['unassigned-print-jobs'],
+  queryFn: () => PrintJobService.searchJobs(),
+  staleTime: 1000 * 15,
+  refetchInterval: 1000 * 30
+})
+
+// The server creates a printer-less PENDING job for ambiguous/unmatched imports
+const unassignedJobs = computed<PrintJobDto[]>(() =>
+  (data.value ?? []).filter(
+    (job) => job.printerId === null && job.status === 'PENDING'
+  )
+)
+
+const dialogOpen = ref(false)
+const activeJob = ref<PrintJobDto | null>(null)
+
+const routingTargetOf = (job: PrintJobDto) =>
+  (job.metadata as { routingTarget?: string } | null)?.routingTarget ?? null
+
+const openRouteDialog = (job: PrintJobDto) => {
+  activeJob.value = job
+  dialogOpen.value = true
+}
+</script>

--- a/src/components/PrintJobs/UnassignedJobsPanel.vue
+++ b/src/components/PrintJobs/UnassignedJobsPanel.vue
@@ -19,7 +19,10 @@
         :key="job.id"
       >
         <v-list-item-title>{{ job.fileName }}</v-list-item-title>
-        <v-list-item-subtitle v-if="routingTargetOf(job)">
+        <v-list-item-subtitle v-if="job.statusReason">
+          {{ job.statusReason }}
+        </v-list-item-subtitle>
+        <v-list-item-subtitle v-else-if="routingTargetOf(job)">
           routing target: {{ routingTargetOf(job) }}
         </v-list-item-subtitle>
         <template #append>

--- a/test/components/PrintJobs/RouteJobDialog.spec.ts
+++ b/test/components/PrintJobs/RouteJobDialog.spec.ts
@@ -1,0 +1,114 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import RouteJobDialog from '@/components/PrintJobs/RouteJobDialog.vue'
+import { usePrinterStore } from '@/store/printer.store'
+
+vi.mock('@/backend/routing.service', () => ({
+  RoutingService: { resolve: vi.fn() }
+}))
+vi.mock('@/backend/print-queue.service', () => ({
+  PrintQueueService: { addToQueue: vi.fn() }
+}))
+vi.mock('@/shared/snackbar.composable', () => ({
+  useSnackbar: () => ({ info: vi.fn(), error: vi.fn() })
+}))
+vi.mock('@/queries/global-queue.query', () => ({
+  useInvalidateGlobalQueue: () => vi.fn()
+}))
+
+import { RoutingService } from '@/backend/routing.service'
+import { PrintQueueService } from '@/backend/print-queue.service'
+
+const resolveMock = RoutingService.resolve as any
+const addToQueueMock = PrintQueueService.addToQueue as any
+
+const printers = [
+  { id: 3, name: 'Prusa Mini 1' },
+  { id: 4, name: 'Prusa Mini 2' },
+  { id: 5, name: 'Voron' }
+]
+const job = { id: 42, fileName: 'part.gcode', fileStorageId: 'fs-1' }
+
+let pinia: ReturnType<typeof createPinia>
+
+function mountDialog(): any {
+  return mount(RouteJobDialog, {
+    props: { modelValue: false, job: job as any },
+    global: {
+      plugins: [createVuetify(), pinia],
+      // Stub the dialog shell — jsdom lacks the overlay APIs; the routing
+      // logic under test lives in the component, not the rendered overlay.
+      stubs: { VDialog: true }
+    }
+  })
+}
+
+describe('RouteJobDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pinia = createPinia()
+    setActivePinia(pinia)
+    usePrinterStore().$patch({ printers: printers as any })
+  })
+
+  it('narrows the printer choice to a tag\'s member printers', async () => {
+    resolveMock.mockResolvedValue({
+      routingTarget: 'fleet',
+      kind: 'tag',
+      matchedName: 'fleet',
+      printerIds: [3, 4]
+    })
+    const wrapper = mountDialog()
+    await wrapper.setProps({ modelValue: true })
+    await flushPromises()
+
+    expect(resolveMock).toHaveBeenCalledWith('fs-1')
+    expect(wrapper.vm.resolution.kind).toBe('tag')
+    expect(wrapper.vm.candidatePrinters.map((p: any) => p.id)).toEqual([3, 4])
+  })
+
+  it('offers every printer for an ambiguous target', async () => {
+    resolveMock.mockResolvedValue({
+      routingTarget: 'voron',
+      kind: 'ambiguous',
+      matchedName: 'voron',
+      printerIds: []
+    })
+    const wrapper = mountDialog()
+    await wrapper.setProps({ modelValue: true })
+    await flushPromises()
+
+    expect(wrapper.vm.resolution.kind).toBe('ambiguous')
+    expect(wrapper.vm.candidatePrinters.map((p: any) => p.id)).toEqual([3, 4, 5])
+  })
+
+  it('routes the job to the selected printer and closes', async () => {
+    const wrapper = mountDialog()
+    wrapper.vm.selectedPrinterId = 4
+    await wrapper.vm.routeJob()
+
+    expect(addToQueueMock).toHaveBeenCalledWith(4, 42)
+    expect(wrapper.emitted('routed')).toBeTruthy()
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([false])
+  })
+
+  it('does nothing when no printer is selected', async () => {
+    const wrapper = mountDialog()
+    await wrapper.vm.routeJob()
+
+    expect(addToQueueMock).not.toHaveBeenCalled()
+    expect(wrapper.emitted('routed')).toBeFalsy()
+  })
+
+  it('keeps the dialog open and does not emit routed when queueing fails', async () => {
+    addToQueueMock.mockRejectedValueOnce(new Error('network'))
+    const wrapper = mountDialog()
+    wrapper.vm.selectedPrinterId = 4
+    await wrapper.vm.routeJob()
+
+    expect(wrapper.emitted('routed')).toBeFalsy()
+    expect(wrapper.vm.routing).toBe(false)
+  })
+})

--- a/test/components/PrintJobs/UnassignedJobsPanel.spec.ts
+++ b/test/components/PrintJobs/UnassignedJobsPanel.spec.ts
@@ -6,12 +6,16 @@ import { VueQueryPlugin, QueryClient } from '@tanstack/vue-query'
 import UnassignedJobsPanel from '@/components/PrintJobs/UnassignedJobsPanel.vue'
 
 vi.mock('@/backend/print-job.service', () => ({
-  PrintJobService: { searchJobs: vi.fn() }
+  PrintJobService: { searchJobs: vi.fn(), deleteJob: vi.fn() }
+}))
+vi.mock('@/shared/snackbar.composable', () => ({
+  useSnackbar: () => ({ info: vi.fn(), error: vi.fn() })
 }))
 
 import { PrintJobService } from '@/backend/print-job.service'
 
 const searchJobsMock = PrintJobService.searchJobs as any
+const deleteJobMock = PrintJobService.deleteJob as any
 
 // A mix the panel must filter: only printer-less PENDING jobs are "unassigned"
 const jobs = [
@@ -45,7 +49,8 @@ function mountPanel(): any {
         createPinia(),
         [VueQueryPlugin, { queryClient: new QueryClient({ defaultOptions: { queries: { retry: false } } }) }]
       ],
-      stubs: { RouteJobDialog: true }
+      // jsdom lacks the overlay APIs Vuetify's VDialog wires up on mount
+      stubs: { RouteJobDialog: true, VDialog: true }
     }
   })
 }
@@ -54,6 +59,7 @@ describe('UnassignedJobsPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     searchJobsMock.mockResolvedValue(jobs)
+    deleteJobMock.mockResolvedValue({ message: 'Job deleted' })
   })
 
   it('lists only printer-less PENDING jobs', async () => {
@@ -81,5 +87,107 @@ describe('UnassignedJobsPanel', () => {
     wrapper.vm.openRouteDialog(jobs[1])
     expect(wrapper.vm.dialogOpen).toBe(true)
     expect(wrapper.vm.activeJob).toEqual(jobs[1])
+  })
+
+  it('dismisses a single job via DELETE /print-jobs/:id (file kept)', async () => {
+    const wrapper = mountPanel()
+    await flushPromises()
+    await flushPromises()
+
+    await wrapper.vm.dismissJob(jobs[0])
+    await flushPromises()
+
+    expect(deleteJobMock).toHaveBeenCalledTimes(1)
+    expect(deleteJobMock).toHaveBeenCalledWith(1)
+  })
+
+  it('toggleSelect adds and removes job ids from selectedIds', async () => {
+    const wrapper = mountPanel()
+    await flushPromises()
+    await flushPromises()
+
+    wrapper.vm.toggleSelect(1)
+    expect(wrapper.vm.selectedIds.has(1)).toBe(true)
+    expect(wrapper.vm.someSelected).toBe(true)
+
+    wrapper.vm.toggleSelect(2)
+    expect([...wrapper.vm.selectedIds].sort()).toEqual([1, 2])
+
+    wrapper.vm.toggleSelect(1)
+    expect(wrapper.vm.selectedIds.has(1)).toBe(false)
+    expect([...wrapper.vm.selectedIds]).toEqual([2])
+  })
+
+  it('Dismiss selected deletes only the chosen subset', async () => {
+    const wrapper = mountPanel()
+    await flushPromises()
+    await flushPromises()
+
+    wrapper.vm.toggleSelect(2)
+    wrapper.vm.openDismissConfirm([...wrapper.vm.selectedIds])
+    await wrapper.vm.confirmDismiss()
+    await flushPromises()
+
+    expect(deleteJobMock).toHaveBeenCalledTimes(1)
+    expect(deleteJobMock).toHaveBeenCalledWith(2)
+    expect(wrapper.vm.selectedIds.has(2)).toBe(false)
+    expect(wrapper.vm.confirmDismissOpen).toBe(false)
+  })
+
+  it('Dismiss all targets every unassigned job', async () => {
+    const wrapper = mountPanel()
+    await flushPromises()
+    await flushPromises()
+
+    wrapper.vm.openDismissConfirm(wrapper.vm.unassignedJobs.map((j: any) => j.id))
+    await wrapper.vm.confirmDismiss()
+    await flushPromises()
+
+    expect(deleteJobMock).toHaveBeenCalledTimes(2)
+    expect(deleteJobMock.mock.calls.map((c: any[]) => c[0]).sort()).toEqual([1, 2])
+    expect(wrapper.vm.confirmDismissOpen).toBe(false)
+  })
+
+  it('keeps selection of jobs whose delete call rejected', async () => {
+    deleteJobMock
+      .mockResolvedValueOnce({ message: 'ok' })
+      .mockRejectedValueOnce(new Error('boom'))
+    const wrapper = mountPanel()
+    await flushPromises()
+    await flushPromises()
+
+    wrapper.vm.toggleSelect(1)
+    wrapper.vm.toggleSelect(2)
+    wrapper.vm.openDismissConfirm([1, 2])
+    await wrapper.vm.confirmDismiss()
+    await flushPromises()
+
+    expect(deleteJobMock).toHaveBeenCalledTimes(2)
+    // The successful one (id=1) is cleared; the rejected one (id=2) stays selected
+    expect(wrapper.vm.selectedIds.has(1)).toBe(false)
+    expect(wrapper.vm.selectedIds.has(2)).toBe(true)
+    expect(wrapper.vm.dismissing).toBe(false)
+  })
+
+  it('drops selection entries whose job is no longer unassigned', async () => {
+    const wrapper = mountPanel()
+    await flushPromises()
+    await flushPromises()
+
+    wrapper.vm.toggleSelect(1)
+    wrapper.vm.toggleSelect(2)
+
+    // Simulate id=1 being routed away (no longer printer-less PENDING)
+    searchJobsMock.mockResolvedValue([
+      { ...jobs[0], printerId: 9, status: 'QUEUED' },
+      jobs[1]
+    ])
+    await wrapper.vm.$.appContext.config.globalProperties // touch reactivity
+    await wrapper.vm.refetch?.()
+    await flushPromises()
+    await flushPromises()
+
+    expect(wrapper.vm.selectedIds.has(1)).toBe(false)
+    expect(wrapper.vm.selectedIds.has(2)).toBe(true)
   })
 })

--- a/test/components/PrintJobs/UnassignedJobsPanel.spec.ts
+++ b/test/components/PrintJobs/UnassignedJobsPanel.spec.ts
@@ -1,0 +1,85 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import { VueQueryPlugin, QueryClient } from '@tanstack/vue-query'
+import UnassignedJobsPanel from '@/components/PrintJobs/UnassignedJobsPanel.vue'
+
+vi.mock('@/backend/print-job.service', () => ({
+  PrintJobService: { searchJobs: vi.fn() }
+}))
+
+import { PrintJobService } from '@/backend/print-job.service'
+
+const searchJobsMock = PrintJobService.searchJobs as any
+
+// A mix the panel must filter: only printer-less PENDING jobs are "unassigned"
+const jobs = [
+  {
+    id: 1,
+    printerId: null,
+    status: 'PENDING',
+    fileName: 'unassigned-a.gcode',
+    fileStorageId: 'fs-a',
+    statusReason: 'matches both a printer and a tag',
+    metadata: { routingTarget: 'voron' }
+  },
+  {
+    id: 2,
+    printerId: null,
+    status: 'PENDING',
+    fileName: 'unassigned-b.gcode',
+    fileStorageId: 'fs-b',
+    statusReason: null,
+    metadata: { routingTarget: 'fleet' }
+  },
+  { id: 3, printerId: 7, status: 'QUEUED', fileName: 'queued.gcode', fileStorageId: 'fs-c', statusReason: null, metadata: null },
+  { id: 4, printerId: null, status: 'COMPLETED', fileName: 'done.gcode', fileStorageId: 'fs-d', statusReason: null, metadata: null }
+]
+
+function mountPanel(): any {
+  return mount(UnassignedJobsPanel, {
+    global: {
+      plugins: [
+        createVuetify(),
+        createPinia(),
+        [VueQueryPlugin, { queryClient: new QueryClient({ defaultOptions: { queries: { retry: false } } }) }]
+      ],
+      stubs: { RouteJobDialog: true }
+    }
+  })
+}
+
+describe('UnassignedJobsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    searchJobsMock.mockResolvedValue(jobs)
+  })
+
+  it('lists only printer-less PENDING jobs', async () => {
+    const wrapper = mountPanel()
+    await flushPromises()
+    await flushPromises()
+
+    expect(wrapper.vm.unassignedJobs.map((j: any) => j.id)).toEqual([1, 2])
+  })
+
+  it('shows the job status reason when present', async () => {
+    const wrapper = mountPanel()
+    await flushPromises()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('unassigned-a.gcode')
+    expect(wrapper.text()).toContain('matches both a printer and a tag')
+  })
+
+  it('opens the route dialog for the chosen job', async () => {
+    const wrapper = mountPanel()
+    await flushPromises()
+    await flushPromises()
+
+    wrapper.vm.openRouteDialog(jobs[1])
+    expect(wrapper.vm.dialogOpen).toBe(true)
+    expect(wrapper.vm.activeJob).toEqual(jobs[1])
+  })
+})

--- a/test/components/PrintJobs/UnassignedJobsPanel.spec.ts
+++ b/test/components/PrintJobs/UnassignedJobsPanel.spec.ts
@@ -111,7 +111,7 @@ describe('UnassignedJobsPanel', () => {
     expect(wrapper.vm.someSelected).toBe(true)
 
     wrapper.vm.toggleSelect(2)
-    expect([...wrapper.vm.selectedIds].sort()).toEqual([1, 2])
+    expect([...wrapper.vm.selectedIds].sort((a: number, b: number) => a - b)).toEqual([1, 2])
 
     wrapper.vm.toggleSelect(1)
     expect(wrapper.vm.selectedIds.has(1)).toBe(false)
@@ -144,7 +144,7 @@ describe('UnassignedJobsPanel', () => {
     await flushPromises()
 
     expect(deleteJobMock).toHaveBeenCalledTimes(2)
-    expect(deleteJobMock.mock.calls.map((c: any[]) => c[0]).sort()).toEqual([1, 2])
+    expect(deleteJobMock.mock.calls.map((c: any[]) => c[0]).sort((a: number, b: number) => a - b)).toEqual([1, 2])
     expect(wrapper.vm.confirmDismissOpen).toBe(false)
   })
 


### PR DESCRIPTION
Part of fdm-monster/fdm-monster#5290. UI for the server's print-file routing (`fdm-monster` `feat/routing-resolution-service`).

- **Files view** — a routing dialog showing where a stored file resolves, with a queue action.
- **Print Jobs page** — an "awaiting printer assignment" panel listing files the server could not auto-route (a tag, no match, or an ambiguous name); each opens a Route dialog that lists the candidate printers and queues the job on the one you pick.
- **Queue tab** live-updates (5s poll) so a routed job shows up without a manual refresh.
- Handles the `ambiguous` resolution kind and surfaces the job's `statusReason`.

Tests: `RouteJobDialog` + `UnassignedJobsPanel` specs added — 26 client tests pass, `vue-tsc` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## New Features

**File routing UI**
- Files view now offers a "Resolve routing" action to see where a stored file would be printed (specific printer, tag match, no match, or ambiguous). If a file resolves to a single printer you can queue it directly from the dialog.

**Unassigned jobs**
- Print Jobs page adds an “Awaiting printer assignment” panel listing jobs the server could not auto-route.
- Each job includes routing status and a “Route…” action to select a printer and queue the job.
- Bulk and per-job dismissal controls (select, dismiss selected, dismiss all) with confirmation; partial failures are handled so successful dismissals apply while failures remain selectable for retry.

**Live queue updates**
- Queue tab auto-refreshes every 5 seconds while active so routed jobs appear without manual refresh; background polling is silent to avoid flashing loading states.

**Improved routing feedback**
- Ambiguous routing and server-provided status reasons are surfaced in the UI so users understand why a job needs manual routing.

Tests
- New unit tests for the routing dialog and unassigned-jobs panel; client tests pass and type checks are clean.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fdm-monster/fdm-monster-client-next/pull/1722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->