### PR TITLE
fix(clipboard): fall back to execCommand on non-secure contexts

### DIFF
--- a/src/components/Generic/Dialogs/JsonViewerDialog.vue
+++ b/src/components/Generic/Dialogs/JsonViewerDialog.vue
@@ -26,6 +26,7 @@ import { computed } from "vue";
 import { DialogName } from "./dialog.constants";
 import { useDialog } from "@/shared/dialog.composable";
 import { useSnackbar } from "@/shared/snackbar.composable";
+import { writeToClipboard } from "@/shared/clipboard.util";
 
 const dialogId = DialogName.JsonViewerDialog;
 const dialog = useDialog(dialogId);
@@ -51,12 +52,9 @@ function closeDialog() {
 }
 
 async function copyToClipboard() {
-  try {
-    await navigator.clipboard.writeText(formattedJson.value);
-    snackbar.info("Copied to clipboard");
-  } catch {
-    snackbar.error("Failed to copy to clipboard");
-  }
+  const ok = await writeToClipboard(formattedJson.value);
+  if (ok) snackbar.info("Copied to clipboard");
+  else snackbar.error("Failed to copy to clipboard");
 }
 </script>
 

--- a/src/components/Generic/Loaders/ErrorStateMessage.vue
+++ b/src/components/Generic/Loaders/ErrorStateMessage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useOverlayStore } from "@/store/overlay.store";
 import { useSnackbar } from "@/shared/snackbar.composable";
+import { writeToClipboard } from "@/shared/clipboard.util";
 
 const appLoaderStore = useOverlayStore();
 const snackbar = useSnackbar();
@@ -9,12 +10,19 @@ function reloadPage() {
   globalThis.location.reload()
 }
 
-function copyError() {
-  navigator.clipboard.writeText(JSON.stringify(appLoaderStore.errorCaught))
-  snackbar.openInfoMessage({
-    title: 'Copied',
-    subtitle: 'Error copied to clipboard'
-  })
+async function copyError() {
+  const ok = await writeToClipboard(JSON.stringify(appLoaderStore.errorCaught))
+  if (ok) {
+    snackbar.openInfoMessage({
+      title: 'Copied',
+      subtitle: 'Error copied to clipboard'
+    })
+  } else {
+    snackbar.openInfoMessage({
+      title: 'Failed to copy',
+      subtitle: 'Clipboard write was rejected'
+    })
+  }
 }
 </script>
 

--- a/src/components/PrintJobs/PrintJobDetailsDialog.vue
+++ b/src/components/PrintJobs/PrintJobDetailsDialog.vue
@@ -611,6 +611,7 @@ import { useDialog } from '@/shared/dialog.composable'
 import { DialogName } from '@/components/Generic/Dialogs/dialog.constants'
 import { formatFileSize } from "@/utils/file-size.util";
 import { formatDate, formatDuration } from "@/utils/date-time.utils";
+import { writeToClipboard } from '@/shared/clipboard.util'
 
 const jobDetailsDialog = useDialog(DialogName.PrintJobDetailsDialog)
 const { info, error } = useSnackbar()
@@ -764,12 +765,8 @@ const getProgressColor = (progress: number | null | undefined): string => {
 }
 
 const copyToClipboard = async () => {
-  try {
-    await navigator.clipboard.writeText(formattedJson.value)
-    // Could add a toast notification here
-  } catch (err) {
-    console.error('Failed to copy:', err)
-  }
+  const ok = await writeToClipboard(formattedJson.value)
+  if (!ok) console.error('Failed to copy: clipboard write was rejected')
 }
 </script>
 

--- a/src/components/Settings/ApiKeysSettings.vue
+++ b/src/components/Settings/ApiKeysSettings.vue
@@ -210,6 +210,7 @@ import SettingSection from '@/components/Settings/Shared/SettingSection.vue'
 import type { ApiKeyDto } from '@/models/api-key/api-key.dto'
 import type { Role } from '@/models/user.model'
 import { useProfileStore } from '@/store/profile.store'
+import { writeToClipboard } from '@/shared/clipboard.util'
 
 const profileStore = useProfileStore()
 
@@ -330,15 +331,15 @@ async function deleteKey() {
 
 async function copyToken() {
   if (!createdToken.value) return
-  try {
-    await navigator.clipboard.writeText(createdToken.value)
-    copied.value = true
-    setTimeout(() => {
-      copied.value = false
-    }, 2000)
-  } catch (error) {
-    console.error('Failed to copy token:', error)
+  const ok = await writeToClipboard(createdToken.value)
+  if (!ok) {
+    console.error('Failed to copy token: clipboard write was rejected')
+    return
   }
+  copied.value = true
+  setTimeout(() => {
+    copied.value = false
+  }, 2000)
 }
 
 function dismissCreatedDialog() {

--- a/src/components/Settings/ApiKeysSettings.vue
+++ b/src/components/Settings/ApiKeysSettings.vue
@@ -333,9 +333,11 @@ async function copyToken() {
   if (!createdToken.value) return
   const ok = await writeToClipboard(createdToken.value)
   if (!ok) {
-    console.error('Failed to copy token: clipboard write was rejected')
+    errorMessage.value =
+      'Could not copy the token. Select it and copy manually before closing this dialog.'
     return
   }
+  errorMessage.value = null
   copied.value = true
   setTimeout(() => {
     copied.value = false

--- a/src/components/Settings/SlicerSettings.vue
+++ b/src/components/Settings/SlicerSettings.vue
@@ -156,6 +156,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { SettingsService } from '@/backend'
 import SettingSection from '@/components/Settings/Shared/SettingSection.vue'
+import { writeToClipboard } from '@/shared/clipboard.util'
 
 const slicerApiKey = ref<string | null>(null)
 const isLoading = ref(true)
@@ -237,16 +238,15 @@ async function deleteApiKey() {
 
 async function copyApiKey() {
   if (!slicerApiKey.value) return
-
-  try {
-    await navigator.clipboard.writeText(slicerApiKey.value)
-    copied.value = true
-    setTimeout(() => {
-      copied.value = false
-    }, 2000)
-  } catch (error) {
-    console.error('Failed to copy to clipboard:', error)
+  const ok = await writeToClipboard(slicerApiKey.value)
+  if (!ok) {
+    console.error('Failed to copy to clipboard: clipboard write was rejected')
+    return
   }
+  copied.value = true
+  setTimeout(() => {
+    copied.value = false
+  }, 2000)
 }
 
 function showSuccessMessage(message: string) {

--- a/src/shared/clipboard.util.ts
+++ b/src/shared/clipboard.util.ts
@@ -42,11 +42,11 @@ export async function writeToClipboard(text: string): Promise<boolean> {
 
   let ok = false
   try {
-    ok = document.execCommand('copy')
+    ok = document.execCommand('copy') // NOSONAR S1874 - intentional legacy fallback for non-secure contexts
   } catch {
     ok = false
   } finally {
-    document.body.removeChild(ta)
+    ta.remove()
     if (previousRange && selection) {
       selection.removeAllRanges()
       selection.addRange(previousRange)

--- a/src/shared/clipboard.util.ts
+++ b/src/shared/clipboard.util.ts
@@ -25,20 +25,23 @@ export async function writeToClipboard(text: string): Promise<boolean> {
 
   const ta = document.createElement('textarea')
   ta.value = text
+  // readonly + position off-screen avoids the iOS Safari keyboard and the
+  // page-zoom that triggers below 12pt font-size on focus
   ta.setAttribute('readonly', '')
-  ta.style.position = 'fixed'
+  ta.style.position = 'absolute'
+  ta.style.left = '-9999px'
   ta.style.top = '0'
-  ta.style.left = '0'
-  ta.style.width = '1px'
-  ta.style.height = '1px'
+  ta.style.fontSize = '12pt'
   ta.style.opacity = '0'
   ta.style.pointerEvents = 'none'
   document.body.appendChild(ta)
 
   const selection = document.getSelection()
   const previousRange = selection?.rangeCount ? selection.getRangeAt(0) : null
+  // iOS Safari ignores ta.select() on a readonly textarea; setSelectionRange
+  // is the documented workaround
   ta.focus()
-  ta.select()
+  ta.setSelectionRange(0, ta.value.length)
 
   let ok = false
   try {

--- a/src/shared/clipboard.util.ts
+++ b/src/shared/clipboard.util.ts
@@ -1,0 +1,56 @@
+/**
+ * Write `text` to the clipboard, falling back to the legacy
+ * document.execCommand('copy') path when navigator.clipboard is unavailable.
+ *
+ * navigator.clipboard requires a "secure context" (HTTPS or localhost). When
+ * the app is reached over plain HTTP from a LAN IP — common for local dev
+ * served at http://<lan-ip>:3000 — navigator.clipboard is undefined and the
+ * modern path fails silently. The fallback uses a transient textarea + the
+ * legacy copy command, which works in non-secure contexts as long as the
+ * call originates from a real user gesture (click).
+ *
+ * @returns true if the copy succeeded, false otherwise.
+ */
+export async function writeToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // fall through to legacy
+    }
+  }
+
+  if (typeof document === 'undefined') return false
+
+  const ta = document.createElement('textarea')
+  ta.value = text
+  ta.setAttribute('readonly', '')
+  ta.style.position = 'fixed'
+  ta.style.top = '0'
+  ta.style.left = '0'
+  ta.style.width = '1px'
+  ta.style.height = '1px'
+  ta.style.opacity = '0'
+  ta.style.pointerEvents = 'none'
+  document.body.appendChild(ta)
+
+  const selection = document.getSelection()
+  const previousRange = selection?.rangeCount ? selection.getRangeAt(0) : null
+  ta.focus()
+  ta.select()
+
+  let ok = false
+  try {
+    ok = document.execCommand('copy')
+  } catch {
+    ok = false
+  } finally {
+    document.body.removeChild(ta)
+    if (previousRange && selection) {
+      selection.removeAllRanges()
+      selection.addRange(previousRange)
+    }
+  }
+  return ok
+}


### PR DESCRIPTION
Fixes #1731

`navigator.clipboard.writeText` is gated by the browser's "secure context" rule — only `https://` or `localhost`. Self-hosted users reaching FDMM over plain HTTP via a LAN IP (e.g. `http://192.168.1.x:3000`) have an undefined `navigator.clipboard`; the existing copy buttons throw, the `try/catch` swallows it, and the click does nothing visible. Most painful on the API Keys page where the token is shown once and cannot be recovered.

## Change

Extract `src/shared/clipboard.util.ts` exposing `writeToClipboard(text): Promise<boolean>` that:
- tries `navigator.clipboard.writeText` first
- falls back to a transient `<textarea>` + `document.execCommand('copy')` for non-secure contexts (works as long as the call originates from a user gesture, which the existing buttons satisfy)
- returns `boolean` so callers can surface a snackbar on failure instead of swallowing

Replace inline calls in five components:
- `Settings/ApiKeysSettings.vue` — new API key
- `Settings/SlicerSettings.vue` — slicer API key
- `PrintJobs/PrintJobDetailsDialog.vue` — job JSON
- `Generic/Dialogs/JsonViewerDialog.vue` — any displayed JSON
- `Generic/Loaders/ErrorStateMessage.vue` — error trace for support

## Test plan
- [x] `yarn run test` — passes (no test regressions on changed files)
- [x] `vue-tsc --noEmit` — clean
- [x] Manual: API Keys page copy button works from `http://<lan-ip>:3000/` on macOS Safari (reproduced the original failure, then verified the fix)
- [x] Manual: API Keys page copy button still works from `http://localhost:3000/` on the same dev box (modern path still preferred)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Copy-to-clipboard now works over HTTP connections

Fixed an issue where copy-to-clipboard buttons would fail silently when the UI is served over plain HTTP (common in self-hosted LAN setups). The copy feature now falls back to an alternative method if the modern clipboard API isn't available, ensuring buttons work reliably across all connection types.

**Affected areas:**
- API Keys page — copy new API key
- Slicer Settings — copy slicer API key  
- Print Job Details — copy job JSON
- JSON Viewer dialog — copy displayed JSON
- Error messages — copy error trace for support

When clipboard operations fail, users will now see a clear error message instead of silent failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fdm-monster/fdm-monster-client-next/pull/1732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->