### PR TITLE
Fix Moonraker API Key field hidden and cleared on save in Add/Update Printer dialog  #

### DIFF
--- a/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
+++ b/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
@@ -103,18 +103,22 @@
             />
 
             <v-text-field
-              v-if="formData.printerType === OctoPrintType"
+              v-if="formData.printerType === OctoPrintType || formData.printerType === MoonrakerType"
               v-model="formData.apiKey"
               :counter="apiKeyRules.length"
               class="ma-1"
-              hint="User or Application Key with 32 or 43 characters (Global API key will fail)"
+              :hint="
+                formData.printerType === OctoPrintType
+                  ? 'User or Application Key with 32 or 43 characters (Global API key will fail)'
+                  : 'Optional — only needed if your Moonraker instance requires authorization (find it under API Key in Mainsail/Fluidd settings)'
+              "
               :label="
-                formData.printerType === OctoPrintType || formData.printerType === MoonrakerType
+                formData.printerType === OctoPrintType
                   ? 'API Key (required)*'
-                  : 'API Key (unsupported)'
+                  : 'API Key (optional)'
               "
               persistent-hint
-              required
+              :required="formData.printerType === OctoPrintType"
             />
 
             <v-text-field
@@ -483,7 +487,7 @@ async function submit() {
 
   const createdPrinter = formData.value as CreatePrinter;
 
-  if (isMoonrakerType(createdPrinter.printerType) || isPrusaLinkType(createdPrinter.printerType) || isBambuType(createdPrinter.printerType)) {
+  if (isPrusaLinkType(createdPrinter.printerType) || isBambuType(createdPrinter.printerType)) {
     createdPrinter.apiKey = "";
   }
 


### PR DESCRIPTION
## Description

The Add/Update Printer dialog had two bugs that made it impossible to actually
configure a Moonraker API key from the UI:

1. The API Key field was only rendered when `printerType === OctoPrintType` —
   Moonraker was never included in the `v-if`, even though the field's own label logic
   already accounted for it. So the field was simply invisible when Moonraker was
   selected.
2. `submit()` unconditionally set `apiKey = ""` for Moonraker (along with
   PrusaLink/Bambu, where that's correct since they use username/password instead)
   right before sending the create/update request — so even entering a key via a
   workaround got wiped before it reached the backend.

Fix:
- Show the API Key field for both OctoPrint and Moonraker, with a Moonraker-specific
  hint/label reflecting that it's optional (only needed if the target Moonraker
  instance requires authorization).
- Only blank `apiKey` on submit for PrusaLink/Bambu, not Moonraker.

**Companion PR:** this is the frontend half of [fdm-monster#5393](https://github.com/fdm-monster/fdm-monster/pull/5393), which makes the
backend actually use this key. Please review/merge together — neither fix is useful
without the other.

## How Has This Been Tested?
- `npx vue-tsc --noEmit` passes clean
- Manually tested against a running FDM Monster backend (with the companion backend
  fix applied) and a real Moonraker printer with authorization enabled: the API Key
  field now appears for Moonraker, survives save, and the printer connects and
  authenticates successfully.

---
This fix was drafted with AI assistance (Claude). I reviewed the change myself and
verified it locally end-to-end against my own printer — it works.
